### PR TITLE
ci: update node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/did-jwt
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:10
     steps:
       - checkout
 
@@ -41,7 +41,7 @@ jobs:
   release:
     working_directory: ~/did-jwt
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:10
     steps:
       - add_ssh_keys:
           fingerprints:


### PR DESCRIPTION
semantic release error in circle: `[semantic-release]: node version >=10.13 is required. Found v8.16.2.`