### PR TITLE
cty header in jwt

### DIFF
--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -42,6 +42,7 @@ interface DIDAuthenticator {
 interface JWTHeader {
   typ: 'JWT'
   alg: string
+  cty?: 'JWT'
 }
 
 interface JWTPayload {
@@ -158,11 +159,13 @@ export function decodeJWT(jwt: string): JWTDecoded {
 // export async function createJWT(payload, { issuer, signer, alg, expiresIn }) {
 export async function createJWT(
   payload: any,
-  { issuer, signer, alg, expiresIn }: JWTOptions
+  { issuer, signer, alg, expiresIn }: JWTOptions,
+  cty?: boolean
 ): Promise<string> {
   if (!signer) throw new Error('No Signer functionality has been configured')
   if (!issuer) throw new Error('No issuing DID has been configured')
-  const header: JWTHeader = { typ: 'JWT', alg: alg || defaultAlg }
+  let header: JWTHeader = { typ: 'JWT', alg: alg || defaultAlg }
+  if (cty) header.cty = 'JWT'
   const timestamps: Partial<JWTPayload> = {
     iat: Math.floor(Date.now() / 1000),
     exp: undefined

--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -42,7 +42,7 @@ interface DIDAuthenticator {
 interface JWTHeader {
   typ: 'JWT'
   alg: string
-  cty?: 'JWT'
+  [x: string]: any
 }
 
 interface JWTPayload {
@@ -54,6 +54,7 @@ interface JWTPayload {
   type?: string
   exp?: number
   rexp?: number
+  [x: string]: any
 }
 
 interface JWTDecoded {
@@ -160,12 +161,12 @@ export function decodeJWT(jwt: string): JWTDecoded {
 export async function createJWT(
   payload: any,
   { issuer, signer, alg, expiresIn }: JWTOptions,
-  cty?: boolean
+  header: Partial<JWTHeader> = {},
 ): Promise<string> {
   if (!signer) throw new Error('No Signer functionality has been configured')
   if (!issuer) throw new Error('No issuing DID has been configured')
-  let header: JWTHeader = { typ: 'JWT', alg: alg || defaultAlg }
-  if (cty) header.cty = 'JWT'
+  if (!header.typ) header.typ = 'JWT'
+  if (!header.alg) header.alg = alg || defaultAlg
   const timestamps: Partial<JWTPayload> = {
     iat: Math.floor(Date.now() / 1000),
     exp: undefined


### PR DESCRIPTION
I need to add the `cty` header parameter in one of my applications, so I added the possibility to add it when creating a JWT. (See [RFC](https://tools.ietf.org/html/rfc7519#section-5.2))

One could also think of a parameter in the createJWT()-method to specify custom headers which get injected into the JWT header, but the cty header alone would be enough for my use case right now.