### PR TITLE
[Bugfix] ES256K vs ES256K-R algorithm handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ docs/styles
 .rts2_cache_cjs
 .rts2_cache_es
 .rts2_cache_umd
+
+.idea/

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "prepare": "npm run build"
   },
   "author": "Pelle Braendgaard <pelle.braendgaard@consensys.net>",
+  "contributors": [
+    "Mircea Nistor <mircea.nistor@consensys.net>"
+  ],
   "license": "Apache-2.0",
   "jest": {
     "transform": {

--- a/src/VerifierAlgorithm.ts
+++ b/src/VerifierAlgorithm.ts
@@ -34,9 +34,22 @@ export function verifyES256K(
 ): PublicKey {
   const hash: Buffer = sha256(data)
   const sigObj: EcdsaSignature = toSignatureObject(signature)
-  const signer: PublicKey = authenticators.find(({ publicKeyHex }) =>
-    secp256k1.keyFromPublic(publicKeyHex, 'hex').verify(hash, sigObj)
+  const fullPublicKeys = authenticators.filter(({ publicKeyHex }) => { return typeof publicKeyHex !== 'undefined' })
+  const ethAddressKeys = authenticators.filter(({ ethereumAddress }) => { return typeof ethereumAddress !== 'undefined' })
+
+  let signer: PublicKey = fullPublicKeys.find(({ publicKeyHex }) => {
+      try {
+        return secp256k1.keyFromPublic(publicKeyHex, 'hex').verify(hash, sigObj)
+      } catch (err) {
+        return false
+      }
+    }
   )
+
+  if (!signer && ethAddressKeys.length > 0) {
+    signer = verifyRecoverableES256K(data, signature, ethAddressKeys)
+  }
+
   if (!signer) throw new Error('Signature invalid for JWT')
   return signer
 }
@@ -46,28 +59,46 @@ export function verifyRecoverableES256K(
   signature: string,
   authenticators: PublicKey[]
 ): PublicKey {
-  const sigObj: EcdsaSignature = toSignatureObject(signature, true)
-  const hash: Buffer = sha256(data)
-  // what type is recoveredKey supposed to be?
-  const recoveredKey: any = secp256k1.recoverPubKey(
-    hash,
-    sigObj,
-    sigObj.recoveryParam
-  )
-  const recoveredPublicKeyHex: string = recoveredKey.encode('hex')
-  const recoveredCompressedPublicKeyHex: string = recoveredKey.encode(
-    'hex',
-    true
-  )
-  const recoveredAddress: string = toEthereumAddress(recoveredPublicKeyHex)
-  const signer: PublicKey = authenticators.find(
-    ({ publicKeyHex, ethereumAddress }) =>
-      publicKeyHex === recoveredPublicKeyHex ||
-      publicKeyHex === recoveredCompressedPublicKeyHex ||
-      ethereumAddress === recoveredAddress
-  )
-  if (!signer) throw new Error('Signature invalid for JWT')
-  return signer
+
+  let signatures: EcdsaSignature[]
+  if (signature.length > 86) {
+    signatures = [ toSignatureObject(signature, true) ]
+  } else {
+    const so = toSignatureObject(signature, false)
+    signatures = [
+       {...so, recoveryParam: 0},
+       {...so, recoveryParam: 1}
+     ]
+  }
+
+  const checkSignatureAgainstSigner = (sigObj: EcdsaSignature) : PublicKey => {
+    const hash: Buffer = sha256(data)
+    // what type is recoveredKey supposed to be?
+    const recoveredKey: any = secp256k1.recoverPubKey(
+      hash,
+      sigObj,
+      sigObj.recoveryParam
+    )
+    const recoveredPublicKeyHex: string = recoveredKey.encode('hex')
+    const recoveredCompressedPublicKeyHex: string = recoveredKey.encode( 'hex', true )
+    const recoveredAddress: string = toEthereumAddress(recoveredPublicKeyHex)
+
+    const signer: PublicKey = authenticators.find(
+      ({ publicKeyHex, ethereumAddress }) =>
+        publicKeyHex === recoveredPublicKeyHex ||
+        publicKeyHex === recoveredCompressedPublicKeyHex ||
+        ethereumAddress === recoveredAddress
+    )
+
+    return signer
+  }
+
+  const signer: PublicKey[] = signatures
+                    .map(checkSignatureAgainstSigner)
+                    .filter( key => key != null )
+
+  if (signer.length == 0) throw new Error('Signature invalid for JWT')
+  return signer[0]
 }
 
 export function verifyEd25519(

--- a/src/VerifierAlgorithm.ts
+++ b/src/VerifierAlgorithm.ts
@@ -73,7 +73,6 @@ export function verifyRecoverableES256K(
 
   const checkSignatureAgainstSigner = (sigObj: EcdsaSignature) : PublicKey => {
     const hash: Buffer = sha256(data)
-    // what type is recoveredKey supposed to be?
     const recoveredKey: any = secp256k1.recoverPubKey(
       hash,
       sigObj,

--- a/src/__tests__/JWT-test.ts
+++ b/src/__tests__/JWT-test.ts
@@ -579,7 +579,7 @@ describe('resolveAuthenticator()', () => {
 
   describe('incorrect format', () => {
     it('throws if token is not valid JWT format', () => {
-      expect( () => decodeJWT("not a jwt") ).toThrow()
+      expect(() => decodeJWT('not a jwt')).toThrow()
     })
   })
 })

--- a/src/__tests__/JWT-test.ts
+++ b/src/__tests__/JWT-test.ts
@@ -47,6 +47,25 @@ const didDoc = {
   ]
 }
 
+const didDocDefault = {
+  '@context': 'https://w3id.org/did/v1',
+  id: did,
+  publicKey: [
+    {
+      id: `${did}#keys-1`,
+      type: 'Secp256k1VerificationKey2018',
+      owner: did,
+      ethereumAddress: address
+    }
+  ],
+  authentication: [
+    {
+      type: 'Secp256k1SignatureAuthentication2018',
+      publicKey: `${did}#keys-1`
+    }
+  ]
+}
+
 describe('createJWT()', () => {
   describe('ES256K', () => {
     it('creates a valid JWT', async () => {
@@ -282,6 +301,16 @@ describe('verifyJWT()', () => {
       { issuer: aud, signer, alg: 'ES256K-R' }
     )
     const { payload } = await verifyJWT(jwt, { resolver })
+    return expect(payload).toMatchSnapshot()
+  })
+
+  it('handles ES256K algorithm with ethereum address - github #14', async () => {
+    const ethResolver = { resolve: jest.fn().mockReturnValue(didDocDefault) }
+    const jwt = await createJWT(
+      { hello: 'world' },
+      { issuer: aud, signer, alg: 'ES256K' }
+    )
+    const { payload } = await verifyJWT(jwt, { resolver: ethResolver })
     return expect(payload).toMatchSnapshot()
   })
 

--- a/src/__tests__/JWT-test.ts
+++ b/src/__tests__/JWT-test.ts
@@ -576,4 +576,10 @@ describe('resolveAuthenticator()', () => {
       expect(() => normalizeDID('notadid!')).toThrow()
     })
   })
+
+  describe('incorrect format', () => {
+    it('throws if token is not valid JWT format', () => {
+      expect( () => decodeJWT("not a jwt") ).toThrow()
+    })
+  })
 })

--- a/src/__tests__/VerifierAlgorithm-test.ts
+++ b/src/__tests__/VerifierAlgorithm-test.ts
@@ -80,6 +80,27 @@ const edKey2 = {
   publicKeyBase64: edPublicKey2
 }
 
+const malformedKey1 = {
+  id: `${did}#keys-7`,
+  type: 'Secp256k1VerificationKey2018',
+  owner: did,
+  publicKeyHex: '05613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab062'
+}
+
+const malformedKey2 = {
+  id: `${did}#keys-8`,
+  type: 'Secp256k1VerificationKey2018',
+  owner: did,
+  publicKeyHex: '04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab062aabbccdd'
+}
+
+const malformedKey3 = {
+  id: `${did}#keys-8`,
+  type: 'Secp256k1VerificationKey2018',
+  owner: did,
+  publicKeyHex: '04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06'
+}
+
 describe('ES256K', () => {
   const verifier = VerifierAlgorithm('ES256K')
   it('validates signature and picks correct public key', async () => {
@@ -98,6 +119,18 @@ describe('ES256K', () => {
     const jwt = await createJWT({ bla: 'bla' }, { issuer: did, signer })
     const parts = jwt.match(/^([a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+)\.([a-zA-Z0-9_-]+)$/)
     return expect(() => verifier(parts[1], parts[2], [ecKey1])).toThrowError(new Error('Signature invalid for JWT'))
+  })
+
+  it('throws error if invalid signature length', async () => {
+    const jwt = await createJWT({ bla: 'bla' }, { issuer: did, signer }) + "aa"
+    const parts = jwt.match(/^([a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+)\.([a-zA-Z0-9_-]+)$/)
+    return expect(() => verifier(parts[1], parts[2], [ecKey1])).toThrowError(new Error('wrong signature length'))
+  })
+
+  it('validates signature with compressed public key and picks correct public key when malformed keys are encountered first', async () => {
+    const jwt = await createJWT({ bla: 'bla' }, { issuer: did, signer })
+    const parts = jwt.match(/^([a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+)\.([a-zA-Z0-9_-]+)$/)
+    return expect(verifier(parts[1], parts[2], [malformedKey1, malformedKey2, malformedKey3, compressedKey])).toEqual(compressedKey)
   })
 
   it('validates signature produced by ethAddress - github #14', async () => {

--- a/src/__tests__/VerifierAlgorithm-test.ts
+++ b/src/__tests__/VerifierAlgorithm-test.ts
@@ -99,6 +99,12 @@ describe('ES256K', () => {
     const parts = jwt.match(/^([a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+)\.([a-zA-Z0-9_-]+)$/)
     return expect(() => verifier(parts[1], parts[2], [ecKey1])).toThrowError(new Error('Signature invalid for JWT'))
   })
+
+  it('validates signature produced by ethAddress - github #14', async () => {
+    const jwt = await createJWT({ bla: 'bla' }, { issuer: did, signer })
+    const parts = jwt.match(/^([a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+)\.([a-zA-Z0-9_-]+)$/)
+    return expect(verifier(parts[1], parts[2], [ethAddress])).toEqual(ethAddress)
+  })
 })
 
 describe('ES256K-R', () => {

--- a/src/__tests__/VerifierAlgorithm-test.ts
+++ b/src/__tests__/VerifierAlgorithm-test.ts
@@ -122,7 +122,7 @@ describe('ES256K', () => {
   })
 
   it('throws error if invalid signature length', async () => {
-    const jwt = await createJWT({ bla: 'bla' }, { issuer: did, signer }) + "aa"
+    const jwt = await createJWT({ bla: 'bla' }, { issuer: did, signer }) + 'aa'
     const parts = jwt.match(/^([a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+)\.([a-zA-Z0-9_-]+)$/)
     return expect(() => verifier(parts[1], parts[2], [ecKey1])).toThrowError(new Error('wrong signature length'))
   })

--- a/src/__tests__/__snapshots__/JWT-test.ts.snap
+++ b/src/__tests__/__snapshots__/JWT-test.ts.snap
@@ -73,7 +73,7 @@ Object {
 }
 `;
 
-exports[`verifyJWT() handles ES256K algorithm with ethereum address 1`] = `
+exports[`verifyJWT() handles ES256K algorithm with ethereum address - github #14 1`] = `
 Object {
   "hello": "world",
   "iat": 1485321133,

--- a/src/__tests__/__snapshots__/JWT-test.ts.snap
+++ b/src/__tests__/__snapshots__/JWT-test.ts.snap
@@ -73,6 +73,14 @@ Object {
 }
 `;
 
+exports[`verifyJWT() handles ES256K algorithm with ethereum address 1`] = `
+Object {
+  "hello": "world",
+  "iat": 1485321133,
+  "iss": "did:ethr:0x20c769ec9c0996ba7737a4826c2aaff00b1b2040",
+}
+`;
+
 exports[`verifyJWT() handles ES256K-R algorithm 1`] = `
 Object {
   "hello": "world",


### PR DESCRIPTION
Default ethr-did documents don't define full `publicKeyHex` key material, only `ethereumAddress`, therefore it's not possible to execute `ecVerify` to check for signatures.
This patch introduces a verification mechanism that defaults to `ecRecover` + string match on `ethereumAddress` in case there is no suitable `publicKeyHex` that can pass verification.

This fixes #14 
This fixes #39 