### PR TITLE
feat: add methods for creating and verifying JWS

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "esm"
   ],
   "scripts": {
-    "test": "./node_modules/.bin/standard && jest --updateSnapshot",
+    "test": "./node_modules/.bin/standard && jest",
     "build:js": "./node_modules/.bin/microbundle",
     "build:browser": "./node_modules/.bin/webpack --config webpack.config.js",
     "build": "npm run build:js && npm test && npm run build:browser",

--- a/src/__tests__/JWT-test.ts
+++ b/src/__tests__/JWT-test.ts
@@ -235,7 +235,7 @@ describe('verifyJWT()', () => {
     // tslint:disable-next-line: max-line-length
     const badJwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzMjExMzMsImlzcyI6ImRpZDpldGhyOjB4MjBjNzY5ZWM5YzA5OTZiYTc3MzdhNDgyNmMyYWFmZjAwYjFiMjA0MCIsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXX0.TTpuw77fUbd_AY3GJcCumd6F6hxnkskMDJYNpJlI2DQi5MKKudXya9NlyM9e8-KFgTLe-WnXgq9EjWLvjpdiXA'
     it('rejects a JWT with bad signature', async () => {
-      expect(verifyJWT(badJwt, { resolver })).rejects.toThrowError(
+      await expect(verifyJWT(badJwt, { resolver })).rejects.toThrowError(
         /Signature invalid for JWT/
       )
     })


### PR DESCRIPTION
This PR add support to create and verify plain JWS. It adds two new functions `createJWS` which is now used by the `createJWT` function, and `verifyJWS` which is **not** used by `verifyJWT` (not much overlap).

In addition I also made some small enhancements:
* Updated the test script to not automatically update the snapshots
* Made the signature verification error messages more informative by adding the token that was failed to verify

