### PR TITLE
fix: make SimpleSigner return a string

### DIFF
--- a/src/SignerAlgorithm.ts
+++ b/src/SignerAlgorithm.ts
@@ -1,32 +1,27 @@
 import base64url from 'uport-base64url'
 import { Buffer } from 'buffer'
 import { Signer, EcdsaSignature, SignerAlgorithm } from './JWT'
+import { ecdsaSigToJose } from './SimpleSigner'
 
 function instanceOfEcdsaSignature(object: any): object is EcdsaSignature {
   return typeof object === 'object' && 'r' in object && 's' in object
 }
 
 export function ES256KSigner(recoverable?: boolean): SignerAlgorithm {
-  function toJose({ r, s, recoveryParam }: EcdsaSignature): string {
-    const jose: Buffer = Buffer.alloc(recoverable ? 65 : 64)
-    Buffer.from(r, 'hex').copy(jose, 0)
-    Buffer.from(s, 'hex').copy(jose, 32)
-    if (recoverable) {
-      if (recoveryParam === undefined) {
-        throw new Error('Signer did not return a recoveryParam')
-      }
-      jose[64] = recoveryParam
-    }
-    return base64url.encode(jose)
-  }
-
   return async function sign(payload: string, signer: Signer): Promise<string> {
-    const signature: EcdsaSignature | string = await signer(payload)
+    let signature: EcdsaSignature | string = await signer(payload)
     if (instanceOfEcdsaSignature(signature)) {
-      return toJose(signature)
-    } else {
-      throw new Error('expected a signer function that returns a signature object instead of string')
+      console.warn('A deprecated version of SimpleSigner detected. Please make sure to update')
+      signature = ecdsaSigToJose(signature)
     }
+    const sigBuf = base64url.toBuffer(signature)
+    if (recoverable && sigBuf.length !== 65) {
+      throw new Error('Signer did not return a recoveryParam')
+    } else if (!recoverable) {
+      // Remove recoveryParam if present
+      if (sigBuf.length === 65) signature = base64url.encode(sigBuf.slice(0, 64))
+    }
+    return signature
   }
 }
 

--- a/src/SimpleSigner.ts
+++ b/src/SimpleSigner.ts
@@ -1,6 +1,7 @@
 import { ec as EC, ec } from 'elliptic'
+import base64url from 'uport-base64url'
 import { sha256 } from './Digest'
-import { Signer } from './JWT'
+import { Signer, EcdsaSignature } from './JWT'
 
 const secp256k1: EC = new EC('secp256k1')
 
@@ -8,6 +9,15 @@ function leftpad(data: string, size = 64): string {
   if (data.length === size) return data
   return '0'.repeat(size - data.length) + data
 }
+
+export function ecdsaSigToJose({ r, s, recoveryParam }: EcdsaSignature): string {
+  const jose: Buffer = Buffer.alloc(65)
+  Buffer.from(r, 'hex').copy(jose, 0)
+  Buffer.from(s, 'hex').copy(jose, 32)
+  jose[64] = recoveryParam
+  return base64url.encode(jose)
+}
+
 /**
  *  The SimpleSigner returns a configured function for signing data. It also defines
  *  an interface that you can also implement yourself and use in our other modules.
@@ -26,11 +36,12 @@ function SimpleSigner(hexPrivateKey: string): Signer {
   const privateKey: ec.KeyPair = secp256k1.keyFromPrivate(hexPrivateKey)
   return async data => {
     const { r, s, recoveryParam }: EC.Signature = privateKey.sign(sha256(data))
-    return {
+    const signatureObj: EcdsaSignature = {
       r: leftpad(r.toString('hex')),
       s: leftpad(s.toString('hex')),
       recoveryParam
     }
+    return ecdsaSigToJose(signatureObj)
   }
 }
 

--- a/src/__tests__/__snapshots__/SimpleSigner-test.ts.snap
+++ b/src/__tests__/__snapshots__/SimpleSigner-test.ts.snap
@@ -1,9 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`signs data 1`] = `
-Object {
-  "r": "8ecbdd2f0aabf8edb4ea191e828abaa5ba3b2c98c269f9442870af7e88413fd5",
-  "recoveryParam": 0,
-  "s": "c9e02ee61b64cf2fd623c8a1296125eaaa452b7d1a02c5079c1d1d75521ecf3b",
-}
-`;
+exports[`signs data 1`] = `"jsvdLwqr-O206hkegoq6pbo7LJjCaflEKHCvfohBP9XJ4C7mG2TPL9YjyKEpYSXqqkUrfRoCxQecHR11Uh7POwA"`;


### PR DESCRIPTION
This PR addresses #78. Now both the NaclSigner and the SimpleSigner (secp256k1) returns JWS signatures. 
The Signer interface and SignerAlgorithm is still backwards compatible but will warn the user that they are using a deprecated version if they return the ecdsa object.

SimpleSigner now returns a recoverable signature by default. The recovery param will be removed if `ES256K` alg is being used.