### PR TITLE
fix: handle SimpleSigner privateKey 0x hex prefix by stripping it

### DIFF
--- a/src/SimpleSigner.ts
+++ b/src/SimpleSigner.ts
@@ -23,6 +23,9 @@ function leftpad(data: string, size = 64): string {
  */
 
 function SimpleSigner(hexPrivateKey: string): Signer {
+  if (hexPrivateKey.startsWith('0x')) {
+    hexPrivateKey = hexPrivateKey.substring(2)
+  }
   const privateKey: ec.KeyPair = secp256k1.keyFromPrivate(hexPrivateKey)
   return async data => {
     const { r, s, recoveryParam }: EC.Signature = privateKey.sign(sha256(data))

--- a/src/__tests__/SimpleSigner-test.ts
+++ b/src/__tests__/SimpleSigner-test.ts
@@ -6,3 +6,10 @@ it('signs data', async () => {
   const plaintext = 'thequickbrownfoxjumpedoverthelazyprogrammer'
   return await expect(signer(plaintext)).resolves.toMatchSnapshot()
 })
+
+const privateKey0x = '0x278a5de700e29faae8e40e366ec5012b5ec63d36ec77e8a2417154cc1d25383f'
+it('signs data: privateKey with 0x prefix', async () => {
+  const signer2 = SimpleSigner(privateKey0x)
+  const plaintext = 'thequickbrownfoxjumpedoverthelazyprogrammer'
+  return await expect(signer2(plaintext)).resolves.toMatchSnapshot()
+})

--- a/src/__tests__/__snapshots__/SimpleSigner-test.ts.snap
+++ b/src/__tests__/__snapshots__/SimpleSigner-test.ts.snap
@@ -7,3 +7,11 @@ Object {
   "s": "c9e02ee61b64cf2fd623c8a1296125eaaa452b7d1a02c5079c1d1d75521ecf3b",
 }
 `;
+
+exports[`signs data: privateKey with 0x prefix 1`] = `
+Object {
+  "r": "8ecbdd2f0aabf8edb4ea191e828abaa5ba3b2c98c269f9442870af7e88413fd5",
+  "recoveryParam": 0,
+  "s": "c9e02ee61b64cf2fd623c8a1296125eaaa452b7d1a02c5079c1d1d75521ecf3b",
+}
+`;


### PR DESCRIPTION
It is common to use 0x as a prefix in hex strings, some libs return private keys with that prefix, but SimpleSigner doesn't handle them.

For example ethers.js HDNode returns a hex string with 0x. It took some time to notice why my signed JWT wasn't valid: `Error: Signature invalid for JWT`.