### PR TITLE
feat: add EllipticSigner that returns string

### DIFF
--- a/src/EllipticSigner.ts
+++ b/src/EllipticSigner.ts
@@ -1,0 +1,32 @@
+import { EcdsaSignature } from './JWT'
+import SimpleSigner from './SimpleSigner'
+import { toJose } from './util'
+
+type Signer = (data: string) => Promise<string>
+// we know that we always get a EcdsaSignature from Simplesigner
+const isEcdsaSig = (obj: any): obj is EcdsaSignature => true
+
+/**
+ *  The EllipticSigner returns a configured function for signing data. It also defines
+ *  an interface that you can also implement yourself and use in our other modules.
+ *
+ *  @example
+ *  const signer = EllipticSigner(process.env.PRIVATE_KEY)
+ *  signer(data, (err, signature) => {
+ *    ...
+ *  })
+ *
+ *  @param    {String}         hexPrivateKey    a hex encoded private key
+ *  @return   {Function}                        a configured signer function
+ */
+function EllipticSigner(hexPrivateKey: string): Signer {
+  const signer = SimpleSigner(hexPrivateKey)
+  return async data => {
+    const signature: EcdsaSignature | string = await signer(data)
+    if (isEcdsaSig(signature)) {
+      return toJose(signature)
+    }
+  }
+}
+
+export default EllipticSigner

--- a/src/__tests__/EllipticSigner-test.ts
+++ b/src/__tests__/EllipticSigner-test.ts
@@ -1,0 +1,15 @@
+import EllipticSigner from '../EllipticSigner'
+
+const privateKey = '278a5de700e29faae8e40e366ec5012b5ec63d36ec77e8a2417154cc1d25383f'
+const signer = EllipticSigner(privateKey)
+it('signs data', async () => {
+  const plaintext = 'thequickbrownfoxjumpedoverthelazyprogrammer'
+  return await expect(signer(plaintext)).resolves.toMatchSnapshot()
+})
+
+const privateKey0x = '0x278a5de700e29faae8e40e366ec5012b5ec63d36ec77e8a2417154cc1d25383f'
+it('signs data: privateKey with 0x prefix', async () => {
+  const signer2 = EllipticSigner(privateKey0x)
+  const plaintext = 'thequickbrownfoxjumpedoverthelazyprogrammer'
+  return await expect(signer2(plaintext)).resolves.toMatchSnapshot()
+})

--- a/src/__tests__/SignerAlgorithm-test.ts
+++ b/src/__tests__/SignerAlgorithm-test.ts
@@ -1,6 +1,7 @@
 import SignerAlgorithm from '../SignerAlgorithm'
 import { toSignatureObject } from '../VerifierAlgorithm'
 import SimpleSigner from '../SimpleSigner'
+import EllipticSigner from '../EllipticSigner'
 import NaclSigner from '../NaclSigner'
 import base64url from 'uport-base64url'
 import { ec as EC } from 'elliptic'
@@ -15,6 +16,7 @@ const ed25519PrivateKey = 'nlXR4aofRVuLqtn9+XVQNlX4s1nVQvp+TOhBBtYls1IG+sHyIkDP/
 const kp = secp256k1.keyFromPrivate(privateKey)
 const signer = SimpleSigner(privateKey)
 const edSigner = NaclSigner(ed25519PrivateKey)
+const ecSigner = EllipticSigner(privateKey)
 const edKp = nacl.sign.keyPair.fromSecretKey(base64ToBytes(ed25519PrivateKey))
 
 describe('SignerAlgorithm', () => {
@@ -58,6 +60,25 @@ describe('ES256K', () => {
 
   it('can verify the signature', async () => {
     const signature = await jwtSigner('hello', signer)
+    expect(kp.verify(sha256('hello'), toSignatureObject(signature))).toBeTruthy()
+  })
+})
+
+describe('ES256K signer which returns signature as string ', () => {
+  const jwtSigner = SignerAlgorithm('ES256K')
+  it('returns correct signature', async () => {
+    return await expect(jwtSigner('hello', ecSigner)).resolves.toEqual(
+      'MaCPcIypS76TnvKSbhbPMG01BJvjQ6ouITV-mVt7_bfTZfGkEdwooSqbzPBHAlZXGzYYvrTnH4M9lF3OZMdpRQ'
+    )
+  })
+
+  it('returns signature of 64 bytes', async () => {
+    const signature = await jwtSigner('hello', ecSigner)
+    expect(base64url.toBuffer(signature).length).toEqual(64)
+  })
+
+  it('can verify the signature', async () => {
+    const signature = await jwtSigner('hello', ecSigner)
     expect(kp.verify(sha256('hello'), toSignatureObject(signature))).toBeTruthy()
   })
 })

--- a/src/__tests__/__snapshots__/EllipticSigner-test.ts.snap
+++ b/src/__tests__/__snapshots__/EllipticSigner-test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`signs data 1`] = `"jsvdLwqr-O206hkegoq6pbo7LJjCaflEKHCvfohBP9XJ4C7mG2TPL9YjyKEpYSXqqkUrfRoCxQecHR11Uh7POw"`;
+
+exports[`signs data: privateKey with 0x prefix 1`] = `"jsvdLwqr-O206hkegoq6pbo7LJjCaflEKHCvfohBP9XJ4C7mG2TPL9YjyKEpYSXqqkUrfRoCxQecHR11Uh7POw"`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import SimpleSigner from './SimpleSigner'
+import EllipticSigner from './EllipticSigner'
 import NaclSigner from './NaclSigner'
 import { verifyJWT, createJWT, decodeJWT, verifyJWS, createJWS, Signer } from './JWT'
 import { toEthereumAddress } from './Digest'
 
-export { SimpleSigner, NaclSigner, verifyJWT, createJWT, decodeJWT, verifyJWS, createJWS, toEthereumAddress, Signer }
+export { SimpleSigner, EllipticSigner, NaclSigner, verifyJWT, createJWT, decodeJWT, verifyJWS, createJWS, toEthereumAddress, Signer }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,23 @@
+import { EcdsaSignature } from './JWT'
+import base64url from 'uport-base64url'
+
 export function base64ToBytes(s: string): Uint8Array {
   return new Uint8Array(Array.prototype.slice.call(Buffer.from(s, 'base64'), 0))
 }
 
 export function bytesToBase64(b: Uint8Array): string {
   return Buffer.from(b).toString('base64')
+}
+
+export function toJose({ r, s, recoveryParam }: EcdsaSignature, recoverable?: boolean): string {
+  const jose: Buffer = Buffer.alloc(recoverable ? 65 : 64)
+  Buffer.from(r, 'hex').copy(jose, 0)
+  Buffer.from(s, 'hex').copy(jose, 32)
+  if (recoverable) {
+    if (recoveryParam === undefined) {
+      throw new Error('Signer did not return a recoveryParam')
+    }
+    jose[64] = recoveryParam
+  }
+  return base64url.encode(jose)
 }


### PR DESCRIPTION
This PR adds a new signer `EllipticSinger` which is similar to `SimpleSigner` but returns a string instead of a signature object. It also adds support for string signatures in `SignerAlgorithms` when using `ES256K`.

Replaces #90 