### PR TITLE
fix: export interfaces used for JWT verification

### DIFF
--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -61,7 +61,7 @@ export interface JWTDecoded {
   data: string
 }
 
-export interface Verified {
+export interface JWTVerified {
   payload: any
   doc: DIDDocument
   issuer: string
@@ -174,10 +174,7 @@ export async function createJWT(
   return createJWS(fullPayload, signer, header)
 }
 
-function verifyJWSDecoded(
-  { header, data, signature }: JWTDecoded,
-  pubkeys: PublicKey | PublicKey[]
-): PublicKey {
+function verifyJWSDecoded({ header, data, signature }: JWTDecoded, pubkeys: PublicKey | PublicKey[]): PublicKey {
   if (!Array.isArray(pubkeys)) pubkeys = [pubkeys]
   const signer: PublicKey = VerifierAlgorithm(header.alg)(data, signature, pubkeys)
   return signer
@@ -228,7 +225,7 @@ export async function verifyJWT(
     audience: null,
     callbackUrl: null
   }
-): Promise<Verified> {
+): Promise<JWTVerified> {
   if (!options.resolver) throw new Error('No DID resolver has been configured')
   const { payload, header, signature, data }: JWTDecoded = decodeJWT(jwt)
   const { doc, authenticators, issuer }: DIDAuthenticator = await resolveAuthenticator(

--- a/src/VerifierAlgorithm.ts
+++ b/src/VerifierAlgorithm.ts
@@ -56,7 +56,10 @@ export function verifyRecoverableES256K(data: string, signature: string, authent
     signatures = [toSignatureObject(signature, true)]
   } else {
     const so = toSignatureObject(signature, false)
-    signatures = [{ ...so, recoveryParam: 0 }, { ...so, recoveryParam: 1 }]
+    signatures = [
+      { ...so, recoveryParam: 0 },
+      { ...so, recoveryParam: 1 }
+    ]
   }
 
   const checkSignatureAgainstSigner = (sigObj: EcdsaSignature): PublicKey => {

--- a/src/__tests__/JWT-test.ts
+++ b/src/__tests__/JWT-test.ts
@@ -120,9 +120,9 @@ describe('createJWT()', () => {
     })
 
     it('throws an error if unsupported algorithm is passed in', async () => {
-      await expect(createJWT({ requested: ['name', 'phone'] }, { issuer: did, signer, alg: 'BADALGO' })).rejects.toThrow(
-        'Unsupported algorithm BADALGO'
-      )
+      await expect(
+        createJWT({ requested: ['name', 'phone'] }, { issuer: did, signer, alg: 'BADALGO' })
+      ).rejects.toThrow('Unsupported algorithm BADALGO')
     })
   })
 
@@ -304,7 +304,9 @@ describe('verifyJWT()', () => {
 
   it('rejects invalid audience', async () => {
     const jwt = await createJWT({ aud }, { issuer: did, signer })
-    await expect(verifyJWT(jwt, { resolver, audience: did })).rejects.toThrow(/JWT audience does not match your DID or callback url/)
+    await expect(verifyJWT(jwt, { resolver, audience: did })).rejects.toThrow(
+      /JWT audience does not match your DID or callback url/
+    )
   })
 
   it('rejects an invalid audience using callback_url where callback is wrong', async () => {
@@ -320,13 +322,15 @@ describe('verifyJWT()', () => {
   it('rejects an invalid audience using callback_url where callback is missing', async () => {
     const jwt = await createJWT({ aud: 'http://pututu.uport.me/unique' }, { issuer: did, signer })
     await expect(verifyJWT(jwt, { resolver })).rejects.toThrow(
-      "JWT audience is required but your app address has not been configured"
+      'JWT audience is required but your app address has not been configured'
     )
   })
 
   it('rejects invalid audience as no address is present', async () => {
     const jwt = await createJWT({ aud }, { issuer: did, signer })
-    await expect(verifyJWT(jwt, { resolver })).rejects.toThrow(/JWT audience is required but your app address has not been configured/)
+    await expect(verifyJWT(jwt, { resolver })).rejects.toThrow(
+      /JWT audience is required but your app address has not been configured/
+    )
   })
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,33 @@
 import SimpleSigner from './SimpleSigner'
 import EllipticSigner from './EllipticSigner'
 import NaclSigner from './NaclSigner'
-import { verifyJWT, createJWT, decodeJWT, verifyJWS, createJWS, Signer } from './JWT'
+import {
+  verifyJWT,
+  createJWT,
+  decodeJWT,
+  verifyJWS,
+  createJWS,
+  Signer,
+  JWTHeader,
+  JWTPayload,
+  JWTVerified,
+  Resolvable
+} from './JWT'
 import { toEthereumAddress } from './Digest'
 
-export { SimpleSigner, EllipticSigner, NaclSigner, verifyJWT, createJWT, decodeJWT, verifyJWS, createJWS, toEthereumAddress, Signer }
+export {
+  SimpleSigner,
+  EllipticSigner,
+  NaclSigner,
+  verifyJWT,
+  createJWT,
+  decodeJWT,
+  verifyJWS,
+  createJWS,
+  toEthereumAddress,
+  Signer,
+  JWTHeader,
+  JWTPayload,
+  JWTVerified,
+  Resolvable
+}


### PR DESCRIPTION
This expands upon the work done in #121
Some of the interfaces are now publicly exported by this module.