### PR TITLE
ci: group automated dependency updates together

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,34 +1,34 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    "group:allNonMajor"
   ],
   "labels": ["maintenance"],
   "packageRules": [
     {
-      "updateTypes": ["minor"],
-      "automerge": true
+      "packagePatterns": [ "jest", "sinon", "codecov", "lint", "jsdoc", "bundle", "prettier", "webpack", "typescript" ],
+      "groupName": "builders-and-testers",
+      "automerge": true,
+      "automergeType": "branch",
+      "schedule": ["before 5am"]
     },
     {
-      "updateTypes": ["patch"],
+      "packagePatterns": [ "semantic", "commitlint" ],
+      "groupName": "automation",
       "automerge": true,
-      "automergeType": "branch"
+      "automergeType": "branch",
+      "schedule": ["before 5am"]
     },
     {
       "depTypeList": ["devDependencies"],
+      "groupName": "devDeps",
       "automerge": true,
-      "automergeType": "branch"
+      "automergeType": "branch",
+      "schedule": ["before 5am"]
     },
     {
-      "packagePatterns": [ "jest" ],
-      "groupName": "jest",
-      "automerge": true,
-      "automergeType": "branch"
-    },
-    {
-      "packagePatterns": [ "lint" ],
-      "groupName": "linters",
-      "automerge": true,
-      "automergeType": "branch"
+      "updateTypes": ["minor", "patch"],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
This should reduce some of the noise created by `renovate` bot when updating dependencies