### PR TITLE
feat: enable detached payloads for JWS

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "author": "Pelle Braendgaard <pelle.braendgaard@consensys.net>",
   "contributors": [
-    "Mircea Nistor <mircea.nistor@consensys.net>"
+    "Mircea Nistor <mircea.nistor@consensys.net>",
+    "Joel Thorstensson <oed@3box.io>"
   ],
   "license": "Apache-2.0",
   "jest": {

--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -140,7 +140,7 @@ export function decodeJWT(jwt: string): JWTDecoded {
  *  @param    {Object}            header            optional object to specify or customize the JWS header
  *  @return   {Promise<Object, Error>}              a promise which resolves with a JWS string or rejects with an error
  */
-export async function createJWS(payload: string | Record<string, any>, signer: Signer, header: Partial<JWTHeader> = {}): Promise<string> {
+export async function createJWS(payload: string | any, signer: Signer, header: Partial<JWTHeader> = {}): Promise<string> {
   if (!header.alg) header.alg = defaultAlg
   const encodedPayload = typeof payload === 'string' ? payload : encodeSection(payload)
   const signingInput: string = [encodeSection(header), encodedPayload].join('.')

--- a/src/__tests__/__snapshots__/JWT-test.ts.snap
+++ b/src/__tests__/__snapshots__/JWT-test.ts.snap
@@ -1,5 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`JWS createJWS works with JSON payload 1`] = `"eyJhbGciOiJFUzI1NksifQ.eyJzb21lIjoiZGF0YSJ9.dblNz-7BVLknOFIBPmt5VTG0MDls_Q69WI8OfQuqNdUp4y50-b8Ubn0xujm1ijfmfqRunpks5TyWqgMsQkR_GQ"`;
+
+exports[`JWS createJWS works with base64url payload 1`] = `"eyJhbGciOiJFUzI1NksifQ.A_3Vet7D1DjqI3_kazPuHgFu2mtYXD4n6mZobC6lNYR5.n5ZZQZe1J7e76TGTLBpQO2R22JFoHDBi5ScfoxHz__Qy7Q6r3R11GdXmY_0ntFx6nC9QbDD19y8tTDMLUM4DAw"`;
+
 exports[`createJWT() ES256K creates a JWT with correct format 1`] = `
 Object {
   "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzMjExMzMsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXSwiaXNzIjoiZGlkOmV0aHI6MHhmM2JlYWMzMGM0OThkOWUyNjg2NWYzNGZjYWE1N2RiYjkzNWIwZDc0In0",


### PR DESCRIPTION
This PR enables a caller of `createJWS` to pass an `base64url` encoded payload directly. This is useful when you need to sign something that isn't a JSON object.