### PR TITLE
chore: reduce package size by not using tweetnacl

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,19 +86,20 @@
     "tslint": "6.1.3",
     "tslint-config-prettier": "1.18.0",
     "tslint-eslint-rules": "5.4.0",
+    "tweetnacl": "^1.0.3",
     "typescript": "4.0.2",
     "webpack": "4.44.1",
     "webpack-cli": "3.3.12"
   },
   "dependencies": {
     "@babel/runtime": "^7.11.2",
+    "@stablelib/ed25519": "^1.0.1",
     "@stablelib/utf8": "^1.0.0",
     "buffer": "^5.6.0",
     "did-resolver": "^2.1.0",
     "elliptic": "^6.5.3",
     "js-sha256": "^0.9.0",
     "js-sha3": "^0.8.0",
-    "tweetnacl": "^1.0.3",
     "uport-base64url": "3.0.2-alpha.0"
   },
   "standard": {

--- a/src/NaclSigner.ts
+++ b/src/NaclSigner.ts
@@ -1,4 +1,4 @@
-import nacl from 'tweetnacl'
+import { sign } from '@stablelib/ed25519'
 import { encode } from '@stablelib/utf8'
 import { Buffer } from 'buffer'
 import { Signer } from './JWT'
@@ -25,7 +25,7 @@ function NaclSigner(base64PrivateKey: string): Signer {
   const privateKey: Uint8Array = base64ToBytes(base64PrivateKey)
   return async data => {
     const dataBytes: Uint8Array = encode(data)
-    const sig: Uint8Array = nacl.sign.detached(dataBytes, privateKey)
+    const sig: Uint8Array = sign(privateKey, dataBytes)
     const b64UrlSig: string = base64url.encode(Buffer.from(sig))
     return b64UrlSig
   }

--- a/src/VerifierAlgorithm.ts
+++ b/src/VerifierAlgorithm.ts
@@ -1,7 +1,7 @@
 import { ec as EC } from 'elliptic'
 import { sha256, toEthereumAddress } from './Digest'
 import base64url from 'uport-base64url'
-import nacl from 'tweetnacl'
+import { verify } from '@stablelib/ed25519'
 import { EcdsaSignature } from './JWT'
 import { PublicKey } from 'did-resolver'
 import { encode } from '@stablelib/utf8'
@@ -89,7 +89,7 @@ export function verifyEd25519(data: string, signature: string, authenticators: P
   const clear: Uint8Array = encode(data)
   const sig: Uint8Array = base64ToBytes(base64url.toBase64(signature))
   const signer: PublicKey = authenticators.find(({ publicKeyBase64 }) =>
-    nacl.sign.detached.verify(clear, sig, base64ToBytes(publicKeyBase64))
+    verify(base64ToBytes(publicKeyBase64), clear, sig)
   )
   if (!signer) throw new Error('Signature invalid for JWT')
   return signer

--- a/yarn.lock
+++ b/yarn.lock
@@ -1600,10 +1600,58 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
+"@stablelib/binary@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@stablelib/binary/-/binary-1.0.0.tgz#fa216f8b2d2f7153878e2bc45e91dddee72c4749"
+  integrity sha512-W01QhOw1tWL51Du1c5JZphJs7toRbfra1C2DBlhT0mRHZWGWB1hpFbqiZUFY7QNIMUpmmHLrlZs3YsSCB/giUg==
+  dependencies:
+    "@stablelib/int" "^1.0.0"
+
+"@stablelib/ed25519@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/ed25519/-/ed25519-1.0.1.tgz#359ca5f59428e9fde9efef9a8f4040ff0a256d67"
+  integrity sha512-kvC98vkJeertRj37yqTcjOwUVYWQ0jcywxxWpeuTal5ZNgH7EcbljtQYECA2Pi2N0zNG0a0AjSD2Q2DFcUxRjQ==
+  dependencies:
+    "@stablelib/random" "^1.0.0"
+    "@stablelib/sha512" "^1.0.0"
+    "@stablelib/wipe" "^1.0.0"
+
+"@stablelib/hash@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@stablelib/hash/-/hash-1.0.0.tgz#28626ddc64cb84db9370f279c5a78cdc96f493ee"
+  integrity sha512-wBvSIIx4Y8799BRD4TBhezS1P9+irGAKdsNgbZMeU5ndMbw7BtZALdCm0FcJIRFxJ2giPLPS9YCgrwWAhzSRLQ==
+
+"@stablelib/int@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@stablelib/int/-/int-1.0.0.tgz#2432569169cc5640fe5e65b7f79f722ed9cacc59"
+  integrity sha512-MRigEQCO7xM93nZqW4CbIBjhANGw3jJxGVSUZH3PQ6HWL1IGrFWVDBzIclWxl4l5aRRpqoM+76ellQNdUJPnsA==
+
+"@stablelib/random@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@stablelib/random/-/random-1.0.0.tgz#f441495075cdeaa45de16d7ddcc269c0b8edb16b"
+  integrity sha512-G9vwwKrNCGMI/uHL6XeWe2Nk4BuxkYyWZagGaDU9wrsuV+9hUwNI1lok2WVo8uJDa2zx7ahNwN7Ij983hOUFEw==
+  dependencies:
+    "@stablelib/binary" "^1.0.0"
+    "@stablelib/wipe" "^1.0.0"
+
+"@stablelib/sha512@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@stablelib/sha512/-/sha512-1.0.0.tgz#91057cfcc15bdda96081ecfb6536b159510a05f6"
+  integrity sha512-qvUu5SraAdGa8HAkAasfMyD9C+MwlRnFVRJ6cRxAEIekmDsU3tfGLnUm3wb9ao4t0FkihGrj8GKlV82TTR4Phw==
+  dependencies:
+    "@stablelib/binary" "^1.0.0"
+    "@stablelib/hash" "^1.0.0"
+    "@stablelib/wipe" "^1.0.0"
+
 "@stablelib/utf8@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@stablelib/utf8/-/utf8-1.0.0.tgz#7c0c039b6d154da50326003ea92777ddc8f5db2c"
   integrity sha512-Y8QWrK4T0yW0HMFfSI3ZaMHKV37q27hX5ilsmKV358x01mzYfj5fwIf2LjzTlF+UIemHEXSlSN9XJnv1ML4znQ==
+
+"@stablelib/wipe@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@stablelib/wipe/-/wipe-1.0.0.tgz#8ed028a10bb7527357b2655c360383b5f07c16ac"
+  integrity sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg==
 
 "@tootallnate/once@1":
   version "1.1.2"


### PR DESCRIPTION
This PR replaces `tweetnacl` with `@stablelib/ed25519` which will reduce the package size. Still keeping `tweetnacl` as a devDep as it's used in a few tests.