### PR TITLE
fix: use EdDSA as the 'alg' header for Ed25519 signatures

### DIFF
--- a/src/SignerAlgorithm.ts
+++ b/src/SignerAlgorithm.ts
@@ -36,7 +36,10 @@ interface SignerAlgorithms {
 const algorithms: SignerAlgorithms = {
   ES256K: ES256KSigner(),
   'ES256K-R': ES256KSigner(true),
-  Ed25519: Ed25519Signer()
+  // This is actually incorrect but retained for backwards compatibility
+  // see https://github.com/decentralized-identity/did-jwt/issues/130
+  Ed25519: Ed25519Signer(),
+  EdDSA: Ed25519Signer()
 }
 
 function SignerAlgorithm(alg: string): SignerAlgorithm {

--- a/src/VerifierAlgorithm.ts
+++ b/src/VerifierAlgorithm.ts
@@ -102,7 +102,10 @@ interface Algorithms {
 const algorithms: Algorithms = {
   ES256K: verifyES256K,
   'ES256K-R': verifyRecoverableES256K,
-  Ed25519: verifyEd25519
+  // This is actually incorrect but retained for backwards compatibility
+  // see https://github.com/decentralized-identity/did-jwt/issues/130
+  Ed25519: verifyEd25519,
+  EdDSA: verifyEd25519
 }
 
 function VerifierAlgorithm(alg: string): Verifier {

--- a/src/__tests__/SignerAlgorithm-test.ts
+++ b/src/__tests__/SignerAlgorithm-test.ts
@@ -32,6 +32,10 @@ describe('SignerAlgorithm', () => {
     expect(typeof SignerAlgorithm('Ed25519')).toEqual('function')
   })
 
+  it('supports EdDSA', () => {
+    expect(typeof SignerAlgorithm('EdDSA')).toEqual('function')
+  })
+
   it('fails on unsupported algorithm', () => {
     expect(() => SignerAlgorithm('BADALGO')).toThrowError('Unsupported algorithm BADALGO')
   })

--- a/src/__tests__/VerifierAlgorithm-test.ts
+++ b/src/__tests__/VerifierAlgorithm-test.ts
@@ -21,6 +21,10 @@ describe('VerifierAlgorithm', () => {
   it('fails on unsupported algorithm', () => {
     expect(() => VerifierAlgorithm('BADALGO')).toThrowError('Unsupported algorithm BADALGO')
   })
+
+  it('supports EdDSA', () => {
+    expect(typeof VerifierAlgorithm('EdDSA')).toEqual('function')
+  })
 })
 
 const mnid = '2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX'


### PR DESCRIPTION
Fixes #130 

I've left the old algorithm parameters in for backwards compatibility. I don't know if this is desirable?