### PR TITLE
Fix/support pubkey encodings

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "@stablelib/ed25519": "^1.0.1",
     "@stablelib/random": "^1.0.0",
     "@stablelib/sha256": "^1.0.0",
-    "@stablelib/utf8": "^1.0.0",
     "@stablelib/x25519": "^1.0.0",
     "@stablelib/xchacha20poly1305": "^1.0.0",
     "did-resolver": "^2.1.1",

--- a/src/NaclSigner.ts
+++ b/src/NaclSigner.ts
@@ -1,7 +1,6 @@
 import { sign } from '@stablelib/ed25519'
-import { encode } from '@stablelib/utf8'
 import { Signer } from './JWT'
-import { base64ToBytes, bytesToBase64url } from './util'
+import { base64ToBytes, bytesToBase64url, stringToBytes } from './util'
 
 /**
  *  The NaclSigner returns a configured function for signing data using the Ed25519 algorithm. It also defines
@@ -22,7 +21,7 @@ import { base64ToBytes, bytesToBase64url } from './util'
 function NaclSigner(base64PrivateKey: string): Signer {
   const privateKey: Uint8Array = base64ToBytes(base64PrivateKey)
   return async data => {
-    const dataBytes: Uint8Array = encode(data)
+    const dataBytes: Uint8Array = stringToBytes(data)
     const sig: Uint8Array = sign(privateKey, dataBytes)
     const b64UrlSig: string = bytesToBase64url(sig)
     return b64UrlSig

--- a/src/VerifierAlgorithm.ts
+++ b/src/VerifierAlgorithm.ts
@@ -2,7 +2,7 @@ import { ec as EC } from 'elliptic'
 import { sha256, toEthereumAddress } from './Digest'
 import { verify } from '@stablelib/ed25519'
 import { PublicKey } from 'did-resolver'
-import { base64ToBytes, base64urlToBytes, bytesToHex, EcdsaSignature, stringToBytes } from './util'
+import { hexToBytes, base58ToBytes, base64ToBytes, base64urlToBytes, bytesToHex, EcdsaSignature, stringToBytes } from './util'
 
 const secp256k1 = new EC('secp256k1')
 
@@ -21,6 +21,17 @@ export function toSignatureObject(signature: string, recoverable = false): Ecdsa
   return sigObj
 }
 
+function extractPublicKeyBytes(pk: PublicKey): Uint8Array {
+  if (pk.publicKeyBase58) {
+    return base58ToBytes(pk.publicKeyBase58)
+  } else if (pk.publicKeyBase64) {
+    return base64ToBytes(pk.publicKeyBase64)
+  } else if (pk.publicKeyHex) {
+    return hexToBytes(pk.publicKeyHex)
+  }
+  return new Uint8Array()
+}
+
 export function verifyES256K(data: string, signature: string, authenticators: PublicKey[]): PublicKey {
   const hash: Uint8Array = sha256(data)
   const sigObj: EcdsaSignature = toSignatureObject(signature)
@@ -31,9 +42,10 @@ export function verifyES256K(data: string, signature: string, authenticators: Pu
     return typeof ethereumAddress !== 'undefined'
   })
 
-  let signer: PublicKey = fullPublicKeys.find(({ publicKeyHex }) => {
+  let signer: PublicKey = fullPublicKeys.find((pk: PublicKey) => {
     try {
-      return secp256k1.keyFromPublic(publicKeyHex, 'hex').verify(hash, sigObj)
+      const pubBytes = extractPublicKeyBytes(pk)
+      return secp256k1.keyFromPublic(pubBytes).verify(hash, sigObj)
     } catch (err) {
       return false
     }
@@ -85,8 +97,9 @@ export function verifyRecoverableES256K(data: string, signature: string, authent
 export function verifyEd25519(data: string, signature: string, authenticators: PublicKey[]): PublicKey {
   const clear: Uint8Array = stringToBytes(data)
   const sig: Uint8Array = base64urlToBytes(signature)
-  const signer: PublicKey = authenticators.find(({ publicKeyBase64 }) =>
-    verify(base64ToBytes(publicKeyBase64), clear, sig)
+  const signer: PublicKey = authenticators.find((pk: PublicKey) => {
+    return verify(extractPublicKeyBytes(pk), clear, sig)
+  }
   )
   if (!signer) throw new Error('Signature invalid for JWT')
   return signer

--- a/src/VerifierAlgorithm.ts
+++ b/src/VerifierAlgorithm.ts
@@ -35,8 +35,8 @@ function extractPublicKeyBytes(pk: PublicKey): Uint8Array {
 export function verifyES256K(data: string, signature: string, authenticators: PublicKey[]): PublicKey {
   const hash: Uint8Array = sha256(data)
   const sigObj: EcdsaSignature = toSignatureObject(signature)
-  const fullPublicKeys = authenticators.filter(({ publicKeyHex }) => {
-    return typeof publicKeyHex !== 'undefined'
+  const fullPublicKeys = authenticators.filter(({ ethereumAddress }) => {
+    return typeof ethereumAddress === 'undefined'
   })
   const ethAddressKeys = authenticators.filter(({ ethereumAddress }) => {
     return typeof ethereumAddress !== 'undefined'

--- a/src/VerifierAlgorithm.ts
+++ b/src/VerifierAlgorithm.ts
@@ -2,8 +2,7 @@ import { ec as EC } from 'elliptic'
 import { sha256, toEthereumAddress } from './Digest'
 import { verify } from '@stablelib/ed25519'
 import { PublicKey } from 'did-resolver'
-import { encode } from '@stablelib/utf8'
-import { base64ToBytes, base64urlToBytes, bytesToHex, EcdsaSignature } from './util'
+import { base64ToBytes, base64urlToBytes, bytesToHex, EcdsaSignature, stringToBytes } from './util'
 
 const secp256k1 = new EC('secp256k1')
 
@@ -84,7 +83,7 @@ export function verifyRecoverableES256K(data: string, signature: string, authent
 }
 
 export function verifyEd25519(data: string, signature: string, authenticators: PublicKey[]): PublicKey {
-  const clear: Uint8Array = encode(data)
+  const clear: Uint8Array = stringToBytes(data)
   const sig: Uint8Array = base64urlToBytes(signature)
   const signer: PublicKey = authenticators.find(({ publicKeyBase64 }) =>
     verify(base64ToBytes(publicKeyBase64), clear, sig)

--- a/src/__tests__/SignerAlgorithm-test.ts
+++ b/src/__tests__/SignerAlgorithm-test.ts
@@ -5,9 +5,8 @@ import EllipticSigner from '../EllipticSigner'
 import NaclSigner from '../NaclSigner'
 import { ec as EC } from 'elliptic'
 import nacl from 'tweetnacl'
-import { base64ToBytes, base64urlToBytes } from '../util'
+import { base64ToBytes, base64urlToBytes, stringToBytes } from '../util'
 import { sha256 } from '../Digest'
-import { encode } from '@stablelib/utf8'
 const secp256k1 = new EC('secp256k1')
 const privateKey = '278a5de700e29faae8e40e366ec5012b5ec63d36ec77e8a241154cc1d25383f'
 const ed25519PrivateKey = 'nlXR4aofRVuLqtn9+XVQNlX4s1nVQvp+TOhBBtYls1IG+sHyIkDP/WN+rWZHGIQp+v2pyct+rkM4asF/YRFQdQ=='
@@ -123,6 +122,6 @@ describe('Ed25519', () => {
 
   it('can verify the signature', async () => {
     const signature = await jwtSigner('hello', edSigner)
-    expect(nacl.sign.detached.verify(encode('hello'), base64urlToBytes(signature), edKp.publicKey)).toBeTruthy()
+    expect(nacl.sign.detached.verify(stringToBytes('hello'), base64urlToBytes(signature), edKp.publicKey)).toBeTruthy()
   })
 })

--- a/src/util.ts
+++ b/src/util.ts
@@ -38,6 +38,10 @@ export function bytesToHex(b: Uint8Array): string {
   return u8a.toString(b, 'base16')
 }
 
+export function stringToBytes(s: string): Uint8Array {
+  return u8a.fromString(s)
+}
+
 export function toJose({ r, s, recoveryParam }: EcdsaSignature, recoverable?: boolean): string {
   const jose = new Uint8Array(recoverable ? 65 : 64)
   jose.set(u8a.fromString(r, 'base16'), 0)

--- a/src/util.ts
+++ b/src/util.ts
@@ -26,6 +26,10 @@ export function base58ToBytes(s: string): Uint8Array {
   return u8a.fromString(s, 'base58btc')
 }
 
+export function hexToBytes(s: string): Uint8Array {
+  return u8a.fromString(s, 'base16')
+}
+
 export function encodeBase64url(s: string): string {
   return bytesToBase64url(u8a.fromString(s))
 }


### PR DESCRIPTION
This PR adds support for multiple public key encodings in the DID document. 
Fixes https://github.com/decentralized-identity/did-jwt/issues/127

Also removes the `@stablelib/utf8` dependency.