### PR TITLE
feat(did auth): update resolution of authentication entries in DIDDocument

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,15 +6,14 @@
       "request": "launch",
       "name": "Jest All",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
-      "args": [
-        "--runInBand", "--coverage=false"
-      ],
-      "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
+      "args": ["--runInBand", "--coverage=false", "JWT-test"],
+      "sourceMaps": true,
       "disableOptimisticBPs": true,
       "windows": {
-        "program": "${workspaceFolder}/node_modules/jest/bin/jest",
-      }
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+      },
+      "resolveSourceMapLocations": ["${workspaceFolder}/**", "!**/node_modules/typescript/lib/typescript.js.map"],
+      "runtimeArgs": ["--preserve-symlinks"]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@stablelib/sha256": "^1.0.0",
     "@stablelib/x25519": "^1.0.0",
     "@stablelib/xchacha20poly1305": "^1.0.0",
-    "did-resolver": "^2.1.1",
+    "did-resolver": "^2.1.2",
     "elliptic": "^6.5.3",
     "js-sha3": "^0.8.0",
     "uint8arrays": "^1.1.0"

--- a/src/__tests__/JWT-test.ts
+++ b/src/__tests__/JWT-test.ts
@@ -436,6 +436,27 @@ describe('resolveAuthenticator()', () => {
     publicKey: edKey.id
   }
 
+  const edKey6 = {
+    id: `${did}#keys-auth6`,
+    type: 'ED25519SignatureVerification',
+    owner: did,
+    publicKeyBase58: 'dummyvalue'
+  }
+  
+  const ecKey7 = {
+    id: `${did}#keys-auth7`,
+    type: 'EcdsaSecp256k1VerificationKey2019',
+    owner: did,
+    publicKeyBase58: 'dummyvalue'
+  }
+
+  const edKey8 = {
+    id: `${did}#keys-auth8`,
+    type: 'Ed25519VerificationKey2018',
+    owner: did,
+    publicKeyBase58: 'dummyvalue'
+  }
+
   const singleKey = {
     '@context': 'https://w3id.org/did/v1',
     id: did,
@@ -447,6 +468,13 @@ describe('resolveAuthenticator()', () => {
     id: did,
     publicKey: [ecKey1, ecKey2, ecKey3, encKey1, edKey, edKey2],
     authentication: [authKey1, authKey2, edAuthKey]
+  }
+
+  const multipleAuthTypes = {
+    '@context': 'https://w3id.org/did/v1',
+    id: did,
+    publicKey: [ecKey1, ecKey2, ecKey3, encKey1, edKey, edKey2, edKey6, ecKey7],
+    authentication: [authKey1, authKey2, edAuthKey, `${did}#keys-auth6`, `${did}#keys-auth7`, edKey8]
   }
 
   const unsupportedFormat = {
@@ -497,6 +525,20 @@ describe('resolveAuthenticator()', () => {
         })
       })
 
+      it('lists authenticators with multiple key types in doc', async () => {
+        const authenticators = await resolveAuthenticator(
+          { resolve: jest.fn().mockReturnValue(multipleAuthTypes) },
+          alg,
+          did,
+          true
+        )
+        return expect(authenticators).toEqual({
+          authenticators: [ecKey1, ecKey2, ecKey7],
+          issuer: did,
+          doc: multipleAuthTypes
+        })
+      })
+
       it('errors if no suitable public keys exist', async () => {
         return await expect(
           resolveAuthenticator({ resolve: jest.fn().mockReturnValue(unsupportedFormat) }, alg, did)
@@ -533,6 +575,20 @@ describe('resolveAuthenticator()', () => {
         })
       })
 
+      it('lists authenticators with multiple key types in doc', async () => {
+        const authenticators = await resolveAuthenticator(
+          { resolve: jest.fn().mockReturnValue(multipleAuthTypes) },
+          alg,
+          did,
+          true
+        )
+        return expect(authenticators).toEqual({
+          authenticators: [edKey, edKey6, edKey8],
+          issuer: did,
+          doc: multipleAuthTypes
+        })
+      })
+
       it('errors if no suitable public keys exist', async () => {
         return await expect(
           resolveAuthenticator({ resolve: jest.fn().mockReturnValue(unsupportedFormat) }, alg, did)
@@ -544,7 +600,7 @@ describe('resolveAuthenticator()', () => {
       return await expect(
         resolveAuthenticator({ resolve: jest.fn().mockReturnValue(singleKey) }, alg, did, true)
       ).rejects.toEqual(
-        new Error(`DID document for ${did} does not have public keys suitable for authenticationg user`)
+        new Error(`DID document for ${did} does not have public keys suitable for authenticating user`)
       )
     })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4226,10 +4226,10 @@ did-resolver@^1.0.0:
   resolved "https://registry.yarnpkg.com/did-resolver/-/did-resolver-1.1.0.tgz#27a63b6f2aa8dee3d622cd8b8b47360661e24f1e"
   integrity sha512-Q02Sc5VuQnJzzR8fQ/DzyCHiYb31WpQdocOsxppI66wwT4XalYRDeCr3a48mL6sYPQo76AkBh0mxte9ZBuQzxA==
 
-did-resolver@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/did-resolver/-/did-resolver-2.1.1.tgz#43796f8a3e921644e5fb15a8147684ca87019cfd"
-  integrity sha512-FYLTkNWofjYNDGV1HTQlyVu1OqZiFxR4I8KM+oxGVOkbXva15NfWzbzciqdXUDqOhe6so5aroAdrVip6gSAYSA==
+did-resolver@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/did-resolver/-/did-resolver-2.1.2.tgz#f1194fdbc087161809ce545e13c11a596f4a3928"
+  integrity sha512-n4YGS1CzbX48U/ChLRY3SdgiV5N3B/+yh0ToS5t+Sx4QjhVZN6ZyijUSSYbFGvz+I4qImeSZOdo6RX8JaieN7A==
 
 diff-sequences@^25.2.6:
   version "25.2.6"


### PR DESCRIPTION
According to the did-core spec the `authentication` entries in a DID document can be either key ID `string` references or embedded `PublicKey` objects.

This PR adds support for that as well as preserving backwards compatibility with the `Authentication` data type used previously by some DID methods.