### PR TITLE
Use stable stringify when creating payload segments

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "jsontokens": "3.0.0",
     "microbundle": "0.13.0",
     "mockdate": "3.0.5",
-    "nacl-did": "1.0.1",
     "prettier": "2.2.1",
     "regenerator-runtime": "0.13.7",
     "semantic-release": "17.4.2",
@@ -88,6 +87,7 @@
     "did-resolver": "^3.1.0",
     "elliptic": "^6.5.4",
     "js-sha3": "^0.8.0",
+    "json-stable-stringify": "^1.0.1",
     "uint8arrays": "^2.1.3"
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -88,10 +88,10 @@
     "@stablelib/sha256": "^1.0.0",
     "@stablelib/x25519": "^1.0.0",
     "@stablelib/xchacha20poly1305": "^1.0.0",
+    "canonicalize": "^1.0.5",
     "did-resolver": "^3.1.0",
     "elliptic": "^6.5.4",
     "js-sha3": "^0.8.0",
-    "json-stable-stringify": "^1.0.1",
     "uint8arrays": "^2.1.3"
   },
   "standard": {

--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -2,6 +2,7 @@ import VerifierAlgorithm from './VerifierAlgorithm'
 import SignerAlg from './SignerAlgorithm'
 import { encodeBase64url, decodeBase64url, EcdsaSignature } from './util'
 import type { Resolvable, VerificationMethod, DIDResolutionResult, DIDDocument } from 'did-resolver'
+import stringify from 'json-stable-stringify';
 
 export type Signer = (data: string | Uint8Array) => Promise<EcdsaSignature | string>
 export type SignerAlgorithm = (payload: string, signer: Signer) => Promise<string>
@@ -123,7 +124,7 @@ const defaultAlg = 'ES256K'
 const DID_JSON = 'application/did+json'
 
 function encodeSection(data: any): string {
-  return encodeBase64url(JSON.stringify(data))
+  return encodeBase64url(stringify(data))
 }
 
 export const NBF_SKEW: number = 300

--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -1,8 +1,8 @@
-import VerifierAlgorithm from './VerifierAlgorithm'
+import canonicalizeData from 'canonicalize'
+import type { DIDDocument, DIDResolutionResult, Resolvable, VerificationMethod } from 'did-resolver'
 import SignerAlg from './SignerAlgorithm'
-import { encodeBase64url, decodeBase64url, EcdsaSignature } from './util'
-import type { Resolvable, VerificationMethod, DIDResolutionResult, DIDDocument } from 'did-resolver'
-import stringify from 'json-stable-stringify';
+import { decodeBase64url, EcdsaSignature, encodeBase64url } from './util'
+import VerifierAlgorithm from './VerifierAlgorithm'
 
 export type Signer = (data: string | Uint8Array) => Promise<EcdsaSignature | string>
 export type SignerAlgorithm = (payload: string, signer: Signer) => Promise<string>
@@ -15,6 +15,7 @@ export interface JWTOptions {
    */
   alg?: string
   expiresIn?: number
+  canonicalize?: boolean
 }
 
 export interface JWTVerifyOptions {
@@ -26,6 +27,10 @@ export interface JWTVerifyOptions {
   skewTime?: number
   /** See https://www.w3.org/TR/did-spec-registries/#verification-relationships */
   proofPurpose?: 'authentication' | 'assertionMethod' | 'capabilityDelegation' | 'capabilityInvocation' | string
+}
+
+export interface JWSCreationOptions {
+  canonicalize?: boolean
 }
 
 export interface DIDAuthenticator {
@@ -123,8 +128,12 @@ export const SUPPORTED_PUBLIC_KEY_TYPES: PublicKeyTypes = {
 const defaultAlg = 'ES256K'
 const DID_JSON = 'application/did+json'
 
-function encodeSection(data: any): string {
-  return encodeBase64url(stringify(data))
+function encodeSection(data: any, shouldCanonicalize: boolean = false): string {
+  if (shouldCanonicalize) {
+    return encodeBase64url(JSON.stringify(canonicalizeData(data)))
+  } else {
+    return encodeBase64url(JSON.stringify(data))
+  }
 }
 
 export const NBF_SKEW: number = 300
@@ -179,11 +188,12 @@ export function decodeJWT(jwt: string): JWTDecoded {
 export async function createJWS(
   payload: string | any,
   signer: Signer,
-  header: Partial<JWTHeader> = {}
+  header: Partial<JWTHeader> = {},
+  options: JWSCreationOptions = {}
 ): Promise<string> {
   if (!header.alg) header.alg = defaultAlg
-  const encodedPayload = typeof payload === 'string' ? payload : encodeSection(payload)
-  const signingInput: string = [encodeSection(header), encodedPayload].join('.')
+  const encodedPayload = typeof payload === 'string' ? payload : encodeSection(payload, options.canonicalize)
+  const signingInput: string = [encodeSection(header, options.canonicalize), encodedPayload].join('.')
 
   const jwtSigner: SignerAlgorithm = SignerAlg(header.alg)
   const signature: string = await jwtSigner(signingInput, signer)
@@ -199,18 +209,19 @@ export async function createJWS(
  *      ...
  *  })
  *
- *  @param    {Object}            payload            payload object
- *  @param    {Object}            [options]          an unsigned credential object
- *  @param    {String}            options.issuer     The DID of the issuer (signer) of JWT
- *  @param    {String}            options.alg        [DEPRECATED] The JWT signing algorithm to use. Supports: [ES256K, ES256K-R, Ed25519, EdDSA], Defaults to: ES256K.
- *                                                   Please use `header.alg` to specify the algorithm
- *  @param    {Signer}            options.signer     a `Signer` function, Please see `ES256KSigner` or `EdDSASigner`
- *  @param    {Object}            header             optional object to specify or customize the JWT header
- *  @return   {Promise<Object, Error>}               a promise which resolves with a signed JSON Web Token or rejects with an error
+ *  @param    {Object}            payload               payload object
+ *  @param    {Object}            [options]             an unsigned credential object
+ *  @param    {String}            options.issuer        The DID of the issuer (signer) of JWT
+ *  @param    {String}            options.alg           [DEPRECATED] The JWT signing algorithm to use. Supports: [ES256K, ES256K-R, Ed25519, EdDSA], Defaults to: ES256K.
+ *                                                      Please use `header.alg` to specify the algorithm
+ *  @param    {Signer}            options.signer        a `Signer` function, Please see `ES256KSigner` or `EdDSASigner`
+ *  @param    {boolean}           options.canonicalize  optional flag to canonicalize header and payload before signing
+ *  @param    {Object}            header                optional object to specify or customize the JWT header
+ *  @return   {Promise<Object, Error>}                  a promise which resolves with a signed JSON Web Token or rejects with an error
  */
 export async function createJWT(
   payload: any,
-  { issuer, signer, alg, expiresIn }: JWTOptions,
+  { issuer, signer, alg, expiresIn, canonicalize }: JWTOptions,
   header: Partial<JWTHeader> = {}
 ): Promise<string> {
   if (!signer) throw new Error('No Signer functionality has been configured')
@@ -229,7 +240,7 @@ export async function createJWT(
     }
   }
   const fullPayload = { ...timestamps, ...payload, iss: issuer }
-  return createJWS(fullPayload, signer, header)
+  return createJWS(fullPayload, signer, header, { canonicalize })
 }
 
 function verifyJWSDecoded(

--- a/src/__tests__/__snapshots__/JWT.test.ts.snap
+++ b/src/__tests__/__snapshots__/JWT.test.ts.snap
@@ -6,7 +6,7 @@ exports[`JWS createJWS works with base64url payload 1`] = `"eyJhbGciOiJFUzI1Nksi
 
 exports[`createJWT() ES256K creates a JWT with correct format 1`] = `
 Object {
-  "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzMjExMzMsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXSwiaXNzIjoiZGlkOmV0aHI6MHhmM2JlYWMzMGM0OThkOWUyNjg2NWYzNGZjYWE1N2RiYjkzNWIwZDc0In0",
+  "data": "eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJpYXQiOjE0ODUzMjExMzMsImlzcyI6ImRpZDpldGhyOjB4ZjNiZWFjMzBjNDk4ZDllMjY4NjVmMzRmY2FhNTdkYmI5MzViMGQ3NCIsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXX0",
   "header": Object {
     "alg": "ES256K",
     "typ": "JWT",
@@ -19,13 +19,13 @@ Object {
       "phone",
     ],
   },
-  "signature": "tU96omPNxCfQoEADOpLywXUDCMjKXOfTaG61EZwmfvHJrDFQhNbSDzCP2Pe7WdXySosTCuI1T-IQ6SddcWuj_A",
+  "signature": "KeedpQ9Z1Nd1wdINmcVHdiNjWOEUf1llBVI5IRgKFGo_alOxqW6K30grzD0jkMVzQS6_xMJFFmticFgILGlVaw",
 }
 `;
 
 exports[`createJWT() ES256K creates a JWT with correct legacy format 1`] = `
 Object {
-  "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzMjExMzMsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXSwiaXNzIjoiMHhmM2JlYWMzMGM0OThkOWUyNjg2NWYzNGZjYWE1N2RiYjkzNWIwZDc0In0",
+  "data": "eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJpYXQiOjE0ODUzMjExMzMsImlzcyI6IjB4ZjNiZWFjMzBjNDk4ZDllMjY4NjVmMzRmY2FhNTdkYmI5MzViMGQ3NCIsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXX0",
   "header": Object {
     "alg": "ES256K",
     "typ": "JWT",
@@ -38,13 +38,13 @@ Object {
       "phone",
     ],
   },
-  "signature": "Ma6o2byDEFmLxmqxJCOXgjAPZftSglFAzzKzv-3kBUkquDPWZyVYK0-vVhH-SbyasahIuHZCDGl4jQrW7hFsAw",
+  "signature": "RMxZj8vDH151eumt-M147Ok-XkVpP7k3QYTMe7eCSzronyqSzww5V4UOMMrZkWy1hH7TFNv9_aqV50Xf1B8fTQ",
 }
 `;
 
 exports[`createJWT() Ed25519 creates a JWT with correct format 1`] = `
 Object {
-  "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZDI1NTE5In0.eyJpYXQiOjE0ODUzMjExMzMsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXSwiaXNzIjoiZGlkOm5hY2w6QnZyQjhpSkF6XzFqZnExbVJ4aUVLZnI5cWNuTGZxNURPR3JCZjJFUlVIVSJ9",
+  "data": "eyJhbGciOiJFZDI1NTE5IiwidHlwIjoiSldUIn0.eyJpYXQiOjE0ODUzMjExMzMsImlzcyI6ImRpZDpuYWNsOkJ2ckI4aUpBel8xamZxMW1SeGlFS2ZyOXFjbkxmcTVET0dyQmYyRVJVSFUiLCJyZXF1ZXN0ZWQiOlsibmFtZSIsInBob25lIl19",
   "header": Object {
     "alg": "Ed25519",
     "typ": "JWT",
@@ -57,7 +57,7 @@ Object {
       "phone",
     ],
   },
-  "signature": "ZoPf01SxW2n5zngunI942FpviEMP6jBZZb9NJ27M_K7AcmjPeeLH8bm2lv0INmJ2u98JVSzELF8YLWQvPYB1Bw",
+  "signature": "MMjmWLR1YShMF5MneteDmzOOEUxAzV2UWkDxuSf12iu9gD7zj5y0-NcoqRUzvkqO-hbUU_QzT_r2nmiLXtPtAQ",
 }
 `;
 

--- a/src/__tests__/__snapshots__/JWT.test.ts.snap
+++ b/src/__tests__/__snapshots__/JWT.test.ts.snap
@@ -1,12 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`JWS createJWS can canonicalize a JSON payload 1`] = `"IntcImFsZ1wiOlwiRVMyNTZLXCJ9Ig.IntcImFcIjpcImFcIixcInpcIjpcInpcIn0i.aKyOmGo5Dx2VsvDZAAHMxNtgqBeI0-qij4OB2AsISFdGsnNDJNEptZkQjY497mzX1LdMPS84pzykqalPtMwqMQ"`;
+
 exports[`JWS createJWS works with JSON payload 1`] = `"eyJhbGciOiJFUzI1NksifQ.eyJzb21lIjoiZGF0YSJ9.dblNz-7BVLknOFIBPmt5VTG0MDls_Q69WI8OfQuqNdUp4y50-b8Ubn0xujm1ijfmfqRunpks5TyWqgMsQkR_GQ"`;
 
 exports[`JWS createJWS works with base64url payload 1`] = `"eyJhbGciOiJFUzI1NksifQ.A_3Vet7D1DjqI3_kazPuHgFu2mtYXD4n6mZobC6lNYR5.n5ZZQZe1J7e76TGTLBpQO2R22JFoHDBi5ScfoxHz__Qy7Q6r3R11GdXmY_0ntFx6nC9QbDD19y8tTDMLUM4DAw"`;
 
 exports[`createJWT() ES256K creates a JWT with correct format 1`] = `
 Object {
-  "data": "eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJpYXQiOjE0ODUzMjExMzMsImlzcyI6ImRpZDpldGhyOjB4ZjNiZWFjMzBjNDk4ZDllMjY4NjVmMzRmY2FhNTdkYmI5MzViMGQ3NCIsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXX0",
+  "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzMjExMzMsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXSwiaXNzIjoiZGlkOmV0aHI6MHhmM2JlYWMzMGM0OThkOWUyNjg2NWYzNGZjYWE1N2RiYjkzNWIwZDc0In0",
   "header": Object {
     "alg": "ES256K",
     "typ": "JWT",
@@ -19,13 +21,13 @@ Object {
       "phone",
     ],
   },
-  "signature": "KeedpQ9Z1Nd1wdINmcVHdiNjWOEUf1llBVI5IRgKFGo_alOxqW6K30grzD0jkMVzQS6_xMJFFmticFgILGlVaw",
+  "signature": "tU96omPNxCfQoEADOpLywXUDCMjKXOfTaG61EZwmfvHJrDFQhNbSDzCP2Pe7WdXySosTCuI1T-IQ6SddcWuj_A",
 }
 `;
 
 exports[`createJWT() ES256K creates a JWT with correct legacy format 1`] = `
 Object {
-  "data": "eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJpYXQiOjE0ODUzMjExMzMsImlzcyI6IjB4ZjNiZWFjMzBjNDk4ZDllMjY4NjVmMzRmY2FhNTdkYmI5MzViMGQ3NCIsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXX0",
+  "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzMjExMzMsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXSwiaXNzIjoiMHhmM2JlYWMzMGM0OThkOWUyNjg2NWYzNGZjYWE1N2RiYjkzNWIwZDc0In0",
   "header": Object {
     "alg": "ES256K",
     "typ": "JWT",
@@ -38,13 +40,13 @@ Object {
       "phone",
     ],
   },
-  "signature": "RMxZj8vDH151eumt-M147Ok-XkVpP7k3QYTMe7eCSzronyqSzww5V4UOMMrZkWy1hH7TFNv9_aqV50Xf1B8fTQ",
+  "signature": "Ma6o2byDEFmLxmqxJCOXgjAPZftSglFAzzKzv-3kBUkquDPWZyVYK0-vVhH-SbyasahIuHZCDGl4jQrW7hFsAw",
 }
 `;
 
 exports[`createJWT() Ed25519 creates a JWT with correct format 1`] = `
 Object {
-  "data": "eyJhbGciOiJFZDI1NTE5IiwidHlwIjoiSldUIn0.eyJpYXQiOjE0ODUzMjExMzMsImlzcyI6ImRpZDpuYWNsOkJ2ckI4aUpBel8xamZxMW1SeGlFS2ZyOXFjbkxmcTVET0dyQmYyRVJVSFUiLCJyZXF1ZXN0ZWQiOlsibmFtZSIsInBob25lIl19",
+  "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZDI1NTE5In0.eyJpYXQiOjE0ODUzMjExMzMsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXSwiaXNzIjoiZGlkOm5hY2w6QnZyQjhpSkF6XzFqZnExbVJ4aUVLZnI5cWNuTGZxNURPR3JCZjJFUlVIVSJ9",
   "header": Object {
     "alg": "Ed25519",
     "typ": "JWT",
@@ -57,7 +59,7 @@ Object {
       "phone",
     ],
   },
-  "signature": "MMjmWLR1YShMF5MneteDmzOOEUxAzV2UWkDxuSf12iu9gD7zj5y0-NcoqRUzvkqO-hbUU_QzT_r2nmiLXtPtAQ",
+  "signature": "ZoPf01SxW2n5zngunI942FpviEMP6jBZZb9NJ27M_K7AcmjPeeLH8bm2lv0INmJ2u98JVSzELF8YLWQvPYB1Bw",
 }
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3287,6 +3287,11 @@ caniuse-lite@^1.0.30001165:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001170.tgz#0088bfecc6a14694969e391cc29d7eb6362ca6a7"
   integrity sha512-Dd4d/+0tsK0UNLrZs3CvNukqalnVTRrxb5mcQm8rHL49t7V5ZaTygwXkrq+FB+dVDf++4ri8eJnFEJAB8332PA==
 
+canonicalize@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/canonicalize/-/canonicalize-1.0.5.tgz#b43b390ce981d397908bb847c3a8d9614323a47b"
+  integrity sha512-mAjKJPIyP0xqqv6IAkvso07StOmz6cmGtNDg3pXCSzXVZOqka7StIkAhJl/zHOi4M2CgpYfD6aeRWbnrmtvBEA==
+
 capture-exit@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-2.0.0.tgz#fb953bfaebeb781f62898239dabb426d08a509a4"
@@ -6948,13 +6953,6 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json-stable-stringify@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
-  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
-  dependencies:
-    jsonify "~0.0.0"
-
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -6989,11 +6987,6 @@ jsonfile@^6.0.1:
     universalify "^1.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
-
-jsonify@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
-  integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
 jsonparse@^1.2.0:
   version "1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4137,11 +4137,6 @@ dezalgo@^1.0.0, dezalgo@~1.0.3:
     asap "^2.0.0"
     wrappy "1"
 
-did-resolver@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/did-resolver/-/did-resolver-1.1.0.tgz#27a63b6f2aa8dee3d622cd8b8b47360661e24f1e"
-  integrity sha512-Q02Sc5VuQnJzzR8fQ/DzyCHiYb31WpQdocOsxppI66wwT4XalYRDeCr3a48mL6sYPQo76AkBh0mxte9ZBuQzxA==
-
 did-resolver@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/did-resolver/-/did-resolver-3.1.0.tgz#84f0e3d16abe9711dc04c34a5a0e2f63868c9611"
@@ -4297,13 +4292,6 @@ ecdsa-sig-formatter@^1.0.11:
   integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
   dependencies:
     safe-buffer "^5.0.1"
-
-ed2curve-esm@^0.3.0-alpha-1:
-  version "0.3.0-alpha-1"
-  resolved "https://registry.yarnpkg.com/ed2curve-esm/-/ed2curve-esm-0.3.0-alpha-1.tgz#67a5722ea97976c3310aeaf0990a2b58ee383aef"
-  integrity sha512-Ydrqcf0NwKUBT4gL0Nnxp8/O5NG8iatN+/zbEgs/7eMGjgSVbgfE1YfWld2qYnoNIxOQvSWOFy5uBoaL3jCanw==
-  dependencies:
-    tweetnacl "^1.0.1"
 
 editor@~1.0.0:
   version "1.0.0"
@@ -6904,6 +6892,13 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
+json-stable-stringify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
+  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
+  dependencies:
+    jsonify "~0.0.0"
+
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -6938,6 +6933,11 @@ jsonfile@^6.0.1:
     universalify "^1.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+jsonify@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
+  integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
 jsonparse@^1.2.0:
   version "1.3.1"
@@ -7818,16 +7818,6 @@ mute-stream@~0.0.4:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
-
-nacl-did@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/nacl-did/-/nacl-did-1.0.1.tgz#94a253430343038c8fee3ff0ecf394b1d34fe4b2"
-  integrity sha512-eGFtGk8v04QaYYQe0Y+suC0iLarPJh4NC5z/f1+JTQh7nRvA/+5ZT4eh/dtP/JGPtUkh2TdpdeiFtMJ0DEyIKQ==
-  dependencies:
-    did-resolver "^1.0.0"
-    ed2curve-esm "^0.3.0-alpha-1"
-    tweetnacl "^1.0.1"
-    tweetnacl-util "^0.15.0"
 
 nanoid@^3.1.20:
   version "3.1.20"
@@ -11062,12 +11052,7 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-tweetnacl-util@^0.15.0:
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz#b80fcdb5c97bcc508be18c44a4be50f022eea00b"
-  integrity sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==
-
-tweetnacl@1.0.3, tweetnacl@^1.0.1:
+tweetnacl@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
   integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==


### PR DESCRIPTION
When creating the segments of a JWT, regular `JSON.stringify()` was being used. Because the ordering is not guaranteed with JSON.stringify - this makes re-creating the JWT out of a W3C format credential very difficult.

By using [json-stable-stringify](https://www.npmjs.com/package/json-stable-stringify) there can be a guaranteed ordering of the properties, meaning as long as the payload contains exactly the same content, you will always get the same JWT (see added test which fails without these changes)

I have also replaced ncal-did with regular jwt decode in the test - nacl-did is [marked as deprecated](https://github.com/uport-project/nacl-did) and was only used in this one place.