### PR TITLE
fix: remove `type` from `JWTPayload`

### DIFF
--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -59,7 +59,6 @@ export interface JWTPayload {
   aud?: string | string[]
   iat?: number
   nbf?: number
-  type?: string
   exp?: number
   rexp?: number
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Fixes #184 