### PR TITLE
feat: enable remote ECDH for JWE [de]encrypters

### DIFF
--- a/src/ECDH.ts
+++ b/src/ECDH.ts
@@ -2,15 +2,21 @@ import { sharedKey } from '@stablelib/x25519'
 
 /**
  * A wrapper around `mySecretKey` that can compute a shared secret using `theirPublicKey`
- * The promise should resolve to a Uint8Array containing the raw shared secret.
+ * The promise should resolve to a `Uint8Array` containing the raw shared secret.
  *
+ * This method is meant to be used when direct access to a secretKey is impossible or not desired.
+ *
+ * @param theirPublicKey `Uint8Array` the other party's publicKey
+ * @returns a `Promise` that resolves to a `Uint8Array` representing the computed shared secret
  */
 export type ECDH = (theirPublicKey: Uint8Array) => Promise<Uint8Array>
 
 /**
  * Wraps an X25519 secretKey into an ECDH method that can be used to compute a shared secret with a publicKey.
- * @param mySecretKey A `Uint8Array` representing the bytes of my secret key
+ * @param mySecretKey A `Uint8Array` of length 32 representing the bytes of my secret key
  * @returns an `ECDH` method with the signature `(theirPublicKey: Uint8Array) => Promise<Uint8Array>`
+ *
+ * @throws 'invalid_argument:...' if the secret key size is wrong
  */
 export function createX25519ECDH(mySecretKey: Uint8Array): ECDH {
   if (mySecretKey.length !== 32) {

--- a/src/ECDH.ts
+++ b/src/ECDH.ts
@@ -1,18 +1,18 @@
 import { sharedKey } from '@stablelib/x25519'
 
 /**
- * A wrapper around `mySecretKey` that can compute a shared secret using `theirPublicKey`
+ * A wrapper around `mySecretKey` that can compute a shared secret using `theirPublicKey`.
  * The promise should resolve to a `Uint8Array` containing the raw shared secret.
  *
- * This method is meant to be used when direct access to a secretKey is impossible or not desired.
+ * This method is meant to be used when direct access to a secret key is impossible or not desired.
  *
- * @param theirPublicKey `Uint8Array` the other party's publicKey
+ * @param theirPublicKey `Uint8Array` the other party's public key
  * @returns a `Promise` that resolves to a `Uint8Array` representing the computed shared secret
  */
 export type ECDH = (theirPublicKey: Uint8Array) => Promise<Uint8Array>
 
 /**
- * Wraps an X25519 secretKey into an ECDH method that can be used to compute a shared secret with a publicKey.
+ * Wraps an X25519 secret key into an ECDH method that can be used to compute a shared secret with a public key.
  * @param mySecretKey A `Uint8Array` of length 32 representing the bytes of my secret key
  * @returns an `ECDH` method with the signature `(theirPublicKey: Uint8Array) => Promise<Uint8Array>`
  *

--- a/src/ECDH.ts
+++ b/src/ECDH.ts
@@ -1,0 +1,25 @@
+import { sharedKey } from '@stablelib/x25519'
+
+/**
+ * A wrapper around `mySecretKey` that can compute a shared secret using `theirPublicKey`
+ * The promise should resolve to a Uint8Array containing the raw shared secret.
+ *
+ */
+export type ECDH = (theirPublicKey: Uint8Array) => Promise<Uint8Array>
+
+/**
+ * Wraps an X25519 secretKey into an ECDH method that can be used to compute a shared secret with a publicKey.
+ * @param mySecretKey A `Uint8Array` representing the bytes of my secret key
+ * @returns an `ECDH` method with the signature `(theirPublicKey: Uint8Array) => Promise<Uint8Array>`
+ */
+export function createX25519ECDH(mySecretKey: Uint8Array): ECDH {
+  if (mySecretKey.length !== 32) {
+    throw new Error('invalid_argument: incorrect secret key length for X25519')
+  }
+  return async (theirPublicKey: Uint8Array): Promise<Uint8Array> => {
+    if (theirPublicKey.length !== 32) {
+      throw new Error('invalid_argument: incorrect publicKey key length for X25519')
+    }
+    return sharedKey(mySecretKey, theirPublicKey)
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
 } from './JWT'
 import { toEthereumAddress } from './Digest'
 export { JWE, createJWE, decryptJWE, Encrypter, Decrypter } from './JWE'
+export { ECDH, createX25519ECDH } from './ECDH'
 export {
   xc20pDirEncrypter,
   xc20pDirDecrypter,

--- a/src/xc20pEncryption.ts
+++ b/src/xc20pEncryption.ts
@@ -17,7 +17,7 @@ export type AuthEncryptParams = {
   kid?: string
 
   /**
-   * sender key ID
+   * See {@link https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-03#section-2.1.1}
    */
   skid?: string
 


### PR DESCRIPTION
With this change, users will be able to use the JWE functionality even without direct access to sender or recipient `secretKey` material, as long as they can provide a wrapper method that resolves to the shared secret.

This also adds a `createX25519ECDH(mySecretKey: Uint8Array): ECDH` method that creates such a wrapper from an existing key.

The signature of the wrapper is this:
```typescript
type ECDH = (theirPublicKey: Uint8Array) => Promise<Uint8Array>
```

fixes #183