### PR TITLE
feat: support `publicKeyMultibase`

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,9 +84,10 @@
     "@stablelib/x25519": "^1.0.1",
     "@stablelib/xchacha20poly1305": "^1.0.1",
     "canonicalize": "^1.0.5",
-    "did-resolver": "^3.1.0",
+    "did-resolver": "^3.1.1",
     "elliptic": "^6.5.4",
     "js-sha3": "^0.8.0",
+    "multiformats": "^9.4.8",
     "uint8arrays": "^3.0.0"
   },
   "eslintIgnore": [

--- a/src/VerifierAlgorithm.ts
+++ b/src/VerifierAlgorithm.ts
@@ -2,6 +2,7 @@ import { ec as EC, SignatureInput } from 'elliptic'
 import { sha256, toEthereumAddress } from './Digest'
 import { verify } from '@stablelib/ed25519'
 import type { VerificationMethod } from 'did-resolver'
+import { bases } from 'multiformats/basics'
 import { hexToBytes, base58ToBytes, base64ToBytes, bytesToHex, EcdsaSignature, stringToBytes } from './util'
 
 const secp256k1 = new EC('secp256k1')
@@ -41,6 +42,10 @@ function extractPublicKeyBytes(pk: VerificationMethod): Uint8Array {
         })
         .getPublic('hex')
     )
+  } else if (pk.publicKeyMultibase) {
+    const { base16, base58btc, base64, base64url } = bases
+    const baseDecoder = base16.decoder.or(base58btc.decoder.or(base64.decoder.or(base64url.decoder)))
+    return baseDecoder.decode(pk.publicKeyMultibase)
   }
   return new Uint8Array()
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
 import * as u8a from 'uint8arrays'
+import { bases } from 'multiformats/basics'
 
 /**
  * @deprecated Signers will be expected to return base64url `string` signatures.
@@ -28,6 +29,10 @@ export function base58ToBytes(s: string): Uint8Array {
 
 export function bytesToBase58(b: Uint8Array): string {
   return u8a.toString(b, 'base58btc')
+}
+
+export function bytesToMultibase(b: Uint8Array, base: keyof typeof bases): string {
+  return bases[base].encode(b)
 }
 
 export function hexToBytes(s: string): Uint8Array {

--- a/src/xc20pEncryption.ts
+++ b/src/xc20pEncryption.ts
@@ -3,7 +3,7 @@ import { generateKeyPair, sharedKey } from '@stablelib/x25519'
 import { randomBytes } from '@stablelib/random'
 import { concatKDF } from './Digest'
 import { bytesToBase64url, base58ToBytes, encodeBase64url, toSealed, base64ToBytes } from './util'
-import { Recipient, EncryptionResult, Encrypter, Decrypter, RecipientHeader, ProtectedHeader } from './JWE'
+import { Recipient, EncryptionResult, Encrypter, Decrypter, ProtectedHeader } from './JWE'
 import type { VerificationMethod, Resolvable } from 'did-resolver'
 import { ECDH } from './ECDH'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3468,10 +3468,10 @@ dezalgo@^1.0.0:
     asap "^2.0.0"
     wrappy "1"
 
-did-resolver@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/did-resolver/-/did-resolver-3.1.0.tgz#84f0e3d16abe9711dc04c34a5a0e2f63868c9611"
-  integrity sha512-uf3/4LfHoDn3Ek8bFegO72OemHMytBhAkud6CA1HlB5I0iVwrCpG4oh+DA6DXUuBdhrA0cY4cGz1D0VNDTlgnw==
+did-resolver@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/did-resolver/-/did-resolver-3.1.1.tgz#1a4fb3b0ea7fe083a6af1be8e60a73d3db0db38b"
+  integrity sha512-6K7Uh/Ewfob3J8Zkprq89InYY0tDu3qu/Nv3TTvL66h9ipRGJB3D5arWIJUwrczFzyuZwu/DXwgKl2PjRnYEUw==
 
 diff-sequences@^27.0.1:
   version "27.0.1"
@@ -6210,6 +6210,11 @@ multiformats@^9.4.2:
   version "9.4.5"
   resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-9.4.5.tgz#9ac47bbc87aadb09d4bd05e9cd3da6f4436414f6"
   integrity sha512-zQxukxsHM34EJi3yT3MkUlycY9wEouyrAz0PSN+CyCj6cYchJZ4LrTH74YtlsxVyAK6waz/gnVLmJwi3P0knKg==
+
+multiformats@^9.4.8:
+  version "9.4.8"
+  resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-9.4.8.tgz#46f74ec116f7871f2a334cc6d4ad3d810dbac341"
+  integrity sha512-EOJL02/kv+FD5hoItMhKgkYUUruJYMYFq4NQ6YkCh3jVQ5CuHo+OKdHeR50hAxEQmXQ9yvrM9BxLIk42xtfwnQ==
 
 mute-stream@~0.0.4:
   version "0.0.8"


### PR DESCRIPTION
This PR adds support for [publicKeyMultibase](https://www.w3.org/TR/did-core/#dfn-publickeymultibase).

TBD: right now, it decodes `base16`, `base58btc`, `base64`, or `base64url` multibase strings only. We could add support for other bases too: `base2`, `base8`, `base10`, `base32`, `base36`, and all their variants. The [multiformats library](https://github.com/multiformats/js-multiformats) doesn't provide a universal decoder. That's why we have to compose our own decoder like this:

```js
 const baseDecoder = base16.decoder.or(base58btc.decoder.or(base64.decoder.or(base64url.decoder)))
```

If you think that `base16`, `base58btc`, `base64`, and `base64url` are enough, then this PR is ready.