### PR TITLE
Allow alternative address prefixes in bip122 blockchain account ids

### DIFF
--- a/src/blockchains/bip122.ts
+++ b/src/blockchains/bip122.ts
@@ -1,12 +1,14 @@
 import * as u8a from 'uint8arrays'
-import { bytesToBase58 } from '../util'
+import { bytesToBase58, base58ToBytes } from '../util'
 import { sha256 } from '../Digest'
 import { Ripemd160 } from './utils/ripemd160'
 
-export const publicKeyToAddress = (publicKey: string): string => {
+export const publicKeyToAddress = (publicKey: string, otherAddress: string): string => {
+  // Use the same version/prefix byte as the given address.
+  const version = u8a.toString(base58ToBytes(otherAddress).slice(0, 1), 'hex')
   const publicKeyBuffer = u8a.fromString(publicKey, 'hex')
   const publicKeyHash = new Ripemd160().update(sha256(publicKeyBuffer)).digest()
-  const step1 = '00' + u8a.toString(publicKeyHash, 'hex')
+  const step1 = version + u8a.toString(publicKeyHash, 'hex')
   const step2 = sha256(u8a.fromString(step1, 'hex'))
   const step3 = sha256(step2)
   const checksum = u8a.toString(step3, 'hex').substring(0, 8)

--- a/src/blockchains/index.ts
+++ b/src/blockchains/index.ts
@@ -7,7 +7,7 @@ export const verifyBlockchainAccountId = (publicKey: string, blockchainAccountId
     const chain = blockchainAccountId.split(':')
     switch (chain[0]) {
       case 'bip122':
-        chain[chain.length - 1] = bip122(publicKey)
+        chain[chain.length - 1] = bip122(publicKey, chain[chain.length - 1])
         break
       case 'cosmos':
         chain[chain.length - 1] = cosmos(publicKey, chain[1])


### PR DESCRIPTION
A Bitcoin address in Base58Check encoding has a version byte prefix that indicates the type or use of the address. Bitcoin mainnet uses a zero byte, but test networks and forks or alternative networks typically use different version bytes.

Here are a few values of version bytes for addresses:

  Hex  |   Network        | Reference
-------|------------------|--------------------
`0x00` | Bitcoin          | https://github.com/bitcoin/bitcoin/blob/fe03f7a37fd0ef05149161f6b95a25493e1fe38f/src/chainparams.cpp#L131
`0x6f` | Bitcoin test     | https://github.com/bitcoin/bitcoin/blob/fe03f7a37fd0ef05149161f6b95a25493e1fe38f/src/chainparams.cpp#L238
`0x30` | Litecoin         | https://github.com/litecoin-project/litecoin/blob/fa0cdba24a0818c4a7206f282c86f0eac6767e72/src/chainparams.cpp#L128
`0x0e` | Feathercoin      | https://github.com/FeatherCoin/Feathercoin/blob/8dad11707024149029bb9bfdd7bc5e10385e0e77/src/chainparams.cpp#L126
`0x1e` | Dogecoin         | https://github.com/dogecoin/dogecoin/blob/31afd133119dd2e15862d46530cb99424cf564b0/src/chainparams.cpp#L167
`0x71` | Dogecoin test    | https://github.com/dogecoin/dogecoin/blob/31afd133119dd2e15862d46530cb99424cf564b0/src/chainparams.cpp#L325

More info:
- https://en.bitcoin.it/wiki/Base58Check_encoding#Version_bytes
- https://en.bitcoin.it/wiki/List_of_address_prefixes
- https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-4.md (defines bip122 for CAIP-2/CAIP-10/blockchainAccountId; does not mention address prefixes)
- https://github.com/decentralized-identity/did-jwt/pull/205 (added blockchainAccountId support)
- https://w3c-ccg.github.io/security-vocab/#blockchainAccountId

This PR updates this implementation to allow using version bytes other than `0x00`, to allow for non-Bitcoin-mainnet addresses.
Essentially it ignores the version byte during verification by passing it through from the address that is being verified against.
The previous behavior was to always use `0x00`, meaning that Bitcoin mainnet address format would need to be used even for testnet and forks/altnets.

If it is desired to verify consistency between the CAIP-4 reference (BIP122 chain ID) and the address byte (e.g. so that an address with the Bitcoin mainnet prefix could only be used with the Bitcoin mainnet chain ID), the byte could instead be looked up from a mapping of known chain ids to version bytes.

These changes do not affect the validity of signature in relation to public keys, only the allowed formats of the account ids (which are hashes of public keys).