### PR TITLE
fix: add missing quotes around undefined

### DIFF
--- a/src/VerifierAlgorithm.ts
+++ b/src/VerifierAlgorithm.ts
@@ -62,7 +62,7 @@ export function verifyES256K(
     return typeof ethereumAddress === 'undefined' && typeof blockchainAccountId === 'undefined'
   })
   const blockchainAddressKeys = authenticators.filter(({ ethereumAddress, blockchainAccountId }) => {
-    return typeof ethereumAddress !== 'undefined' || typeof blockchainAccountId !== undefined
+    return typeof ethereumAddress !== 'undefined' || typeof blockchainAccountId !== 'undefined'
   })
 
   let signer: VerificationMethod | undefined = fullPublicKeys.find((pk: VerificationMethod) => {


### PR DESCRIPTION
This is a quick fix adding missing quotes around `undefined`.

Without the quotes, `typeof blockchainAccountId !== undefined` always return `true`, and all the `authenticators` are added to `blockchainAddressKeys`, which causes the lib to unnecessarily call `signer = verifyRecoverableES256K(data, signature, blockchainAddressKeys)` (line 78) when `signer` is falsy.