### PR TITLE
fix: remove nullish coalescing operator

### DIFF
--- a/src/xc20pEncryption.ts
+++ b/src/xc20pEncryption.ts
@@ -314,7 +314,7 @@ export async function resolveX25519Encrypters(dids: string[], resolver: Resolvab
       agreementKeys?.filter((key) => {
         // TODO: should be able to use non base58 keys too
         return key.type === 'X25519KeyAgreementKey2019' && Boolean(key.publicKeyBase58)
-      }) ?? []
+      }) || []
     if (!pks.length && !controllerEncrypters.length)
       throw new Error(`no_suitable_keys: Could not find x25519 key for ${did}`)
     return pks


### PR DESCRIPTION
I'm not sure why but bundlers don't seem to pick this up and translate it, but since it is safe to replace the single use of that operator why not make it easier?

fixes #236