### PR TITLE
Introduced Policies to override Timestamp checking

### DIFF
--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -38,9 +38,9 @@ export interface JWTVerifyOptions {
 }
 
 export interface JWTVerifyPolicies {
-  now?: boolean,
-  nbf?: boolean,
-  iat?: boolean,
+  now?: boolean
+  nbf?: boolean
+  iat?: boolean
   exp?: boolean
 }
 
@@ -338,8 +338,8 @@ export async function verifyJWT(
       nbf: undefined,
       iat: undefined,
       exp: undefined,
-      now: undefined
-    }
+      now: undefined,
+    },
   }
 ): Promise<JWTVerified> {
   if (!options.resolver) throw new Error('missing_resolver: No DID resolver has been configured')
@@ -349,7 +349,7 @@ export async function verifyJWT(
       ? 'authentication'
       : undefined
     : options.proofPurpose
-  
+
   let did = ''
 
   if (!payload.iss) {

--- a/src/__tests__/JWT.test.ts
+++ b/src/__tests__/JWT.test.ts
@@ -502,7 +502,7 @@ describe('verifyJWT()', () => {
       // const jwt = await createJWT({iat:FUTURE},{issuer:did,signer})
       await expect(verifyJWT(jwt, { resolver })).rejects.toThrowError()
     })
-    it('fails when nbf is missing and iat is in the future', async () => {
+    it('passes when nbf is missing and iat is in the future with iat policy to be false', async () => {
       expect.assertions(1)
       const jwt =
         'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzODExMzMsImlzcyI6ImRpZDpldGhyOjB4ZjNiZWFjMzBjNDk4ZDllMjY4NjVmMzRmY2FhNTdkYmI5MzViMGQ3NCJ9.FJuHvf9Tby7b4I54Cm1nh8CvLg4QH2wt2K0WfyQaLqlr3NKKI5hAdLalgZksI25gLhNrZwQFnC-nzEOs9PI1SQ'

--- a/src/__tests__/JWT.test.ts
+++ b/src/__tests__/JWT.test.ts
@@ -473,14 +473,14 @@ describe('verifyJWT()', () => {
       return expect(payload).toBeDefined()
     })
 
-    it.only('passes when nbf is in the future and policy for nbf is false and policy for now is true', async () => {
+    it('passes when nbf is in the future and now is provided to be higher than nbf', async () => {
       expect.assertions(2)
       // const jwt = await createJWT({nbf:FUTURE},{issuer:did,signer})
 
-      const jwt = await createJWT({ requested: ['name', 'phone'], nbf: new Date().getTime() + 1000000 }, { issuer: did, signer })
+      const jwt = await createJWT({ requested: ['name', 'phone'], nbf: new Date().getTime() + 10000 }, { issuer: did, signer })
       expect(verifier.verify(jwt)).toBe(true)
 
-      const { payload } = await verifyJWT(jwt, { resolver, policies: { nbf: false, now: true } })
+      const { payload } = await verifyJWT(jwt, { resolver, policies: { now: new Date().getTime() + 100000 } })
       return expect(payload).toBeDefined()
     })
 
@@ -630,13 +630,6 @@ describe('verifyJWT()', () => {
     expect.assertions(1)
     const jwt = await createJWT({ exp: NOW - NBF_SKEW - 1 }, { issuer: did, signer })
     const { payload } = await verifyJWT(jwt, { resolver, policies: { exp: false } })
-    return expect(payload).toBeDefined()
-  })
-
-  it('accepts an expired JWT with nbf in the future and with now policy false', async () => {
-    expect.assertions(1)
-    const jwt = await createJWT({ exp: NOW - NBF_SKEW - 1, nbf: new Date().getTime() + 1000000 }, { issuer: did, signer })
-    const { payload } = await verifyJWT(jwt, { resolver, policies: { now: false } })
     return expect(payload).toBeDefined()
   })
 

--- a/src/__tests__/JWT.test.ts
+++ b/src/__tests__/JWT.test.ts
@@ -472,6 +472,19 @@ describe('verifyJWT()', () => {
       const { payload } = await verifyJWT(jwt, { resolver, policies: { nbf: false } })
       return expect(payload).toBeDefined()
     })
+
+    it.only('passes when nbf is in the future and policy for nbf is false and policy for now is true', async () => {
+      expect.assertions(2)
+      // const jwt = await createJWT({nbf:FUTURE},{issuer:did,signer})
+
+      const jwt = await createJWT({ requested: ['name', 'phone'], nbf: new Date().getTime() + 1000000 }, { issuer: did, signer })
+      expect(verifier.verify(jwt)).toBe(true)
+
+      const { payload } = await verifyJWT(jwt, { resolver, policies: { nbf: false, now: true } })
+      return expect(payload).toBeDefined()
+    })
+
+
     it('fails when nbf is in the future and iat is in the past', async () => {
       expect.assertions(1)
       const jwt =
@@ -617,6 +630,13 @@ describe('verifyJWT()', () => {
     expect.assertions(1)
     const jwt = await createJWT({ exp: NOW - NBF_SKEW - 1 }, { issuer: did, signer })
     const { payload } = await verifyJWT(jwt, { resolver, policies: { exp: false } })
+    return expect(payload).toBeDefined()
+  })
+
+  it('accepts an expired JWT with nbf in the future and with now policy false', async () => {
+    expect.assertions(1)
+    const jwt = await createJWT({ exp: NOW - NBF_SKEW - 1, nbf: new Date().getTime() + 1000000 }, { issuer: did, signer })
+    const { payload } = await verifyJWT(jwt, { resolver, policies: { now: false } })
     return expect(payload).toBeDefined()
   })
 


### PR DESCRIPTION
## Pull Request to Introduce Policies for VerifyJWT

### Description
This merge requests introduces a new interface in the JWT.ts module which JWTVerifyPolicies. The policies at the moment are only restricted to timestamps, but can be further expanded upon to serve better. The JWTVerifyPolicies are made a part of VerifyJWTOptions defined as `policies`. These policies are used to be able to override a certain checks that are made in the VerifyJWT command. It is not a breaking change but an extension to the current implementation.

### Policies
The checks for these policies will not me made only and only if they are explicitly stated to be 
- nbf  (Not Before)
- iat   (Issued At)
- exp (Expires At)

### Tests
Further tests were added to the JWT.test.ts to check whether the implemented policies were properly allowing the presentation to verify in case of a failure and the policy was made to be overridden. The following cases are covered:
- nbf is in the future and policy for nbf is false
- nbf is in the future and iat is in the past with nbf policy false
- expired JWT with exp policy false
- expired JWT without skew time but exp policy false
- iat is in the future with iat policy false
