### PR TITLE
feat: add `aud` override policy for verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![npm](https://img.shields.io/npm/dt/did-jwt.svg)](https://www.npmjs.com/package/did-jwt)
 [![npm](https://img.shields.io/npm/v/did-jwt.svg)](https://www.npmjs.com/package/did-jwt)
-[![Twitter Follow](https://img.shields.io/twitter/follow/uport_me.svg?style=social&label=Follow)](https://twitter.com/uport_me)
+[![Twitter Follow](https://img.shields.io/twitter/follow/veramolabs.svg?style=social&label=Follow)](https://twitter.com/veramolabs)
 [![codecov](https://codecov.io/gh/decentralized-identity/did-jwt/branch/master/graph/badge.svg)](https://codecov.io/gh/decentralized-identity/did-jwt)
 
 # did-jwt
@@ -14,7 +14,7 @@ identity of the token, which is passed as the `iss` attribute of the JWT payload
 
 ## DID methods
 
-All DID methods that can be resolved using the [`did-resolver'](https://github.com/decentralized-identity/did-resolver)
+All DID methods that can be resolved using the [`did-resolver`](https://github.com/decentralized-identity/did-resolver)
 interface are supported for verification.
 
 If your DID method requires a different signing algorithm than what is already supported, please create an issue.
@@ -35,15 +35,16 @@ yarn add did-jwt
 
 ### 1. Create a did-JWT
 
-In practice, you must secure the key passed to ES256KSigner. The key provided in code below is for informational
+In practice, you must secure the key passed to `ES256KSigner`. The key provided in code below is for informational
 purposes only.
 
-```js
-const didJWT = require('did-jwt')
+```ts
+import didJWT from 'did-jwt';
+
 const signer = didJWT.ES256KSigner(didJWT.hexToBytes('278a5de700e29faae8e40e366ec5012b5ec63d36ec77e8a2417154cc1d25383f'))
 
 let jwt = await didJWT.createJWT(
-  { aud: 'did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74', exp: 1957463421, name: 'uPort Developer' },
+  { aud: 'did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74', iat: undefined, name: 'uPort Developer' },
   { issuer: 'did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74', signer },
   { alg: 'ES256K' }
 )
@@ -62,19 +63,17 @@ console.log(decoded)
 
 Once decoded a did-JWT will resemble:
 
-```js
-{
-  header: { typ: 'JWT', alg: 'ES256K' },
+```ts
+expect(decoded).toEqual({
+  header: { alg: 'ES256K', typ: 'JWT' },
   payload: {
-    iat: 1571692233,
-    exp: 1957463421,
     aud: 'did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74',
     name: 'uPort Developer',
     iss: 'did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74'
   },
-  signature: 'kkSmdNE9Xbiql_KCg3IptuJotm08pSEeCOICBCN_4YcgyzFc4wIfBdDQcz76eE-z7xUR3IBb6-r-lRfSJcHMiAA',
-  data: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzE2OTIyMzMsImV4cCI6MTk1NzQ2MzQyMSwiYXVkIjoiZGlkOmV0aHI6MHhmM2JlYWMzMGM0OThkOWUyNjg2NWYzNGZjYWE1N2RiYjkzNWIwZDc0IiwibmFtZSI6InVQb3J0IERldmVsb3BlciIsImlzcyI6ImRpZDpldGhyOjB4ZjNiZWFjMzBjNDk4ZDllMjY4NjVmMzRmY2FhNTdkYmI5MzViMGQ3NCJ9'
-}
+  signature: 'mAhpAnw-9u57hyAaDufj2GPMbmuZyPDlU7aYSUMKk7P_9_cF3iLk-hFjFhb5xaUQB5nXYrciw6ZJ2RSAZI-IDQ',
+  data: 'eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQiLCJuYW1lIjoidVBvcnQgRGV2ZWxvcGVyIiwiaXNzIjoiZGlkOmV0aHI6MHhmM2JlYWMzMGM0OThkOWUyNjg2NWYzNGZjYWE1N2RiYjkzNWIwZDc0In0'
+})
 ```
 
 ### 3. Verify a did-JWT
@@ -88,14 +87,14 @@ npm install ethr-did-resolver
 ```
 
 ```js
-const Resolver = require('did-resolver')
-const ethrDid = require('ethr-did-resolver').getResolver({ rpcUrl: 'https://mainnet.infura.io/v3/...' })
+import {Resolver} from 'did-resolver';
+import {getResolver} from 'ethr-did-resolver'
 
-let resolver = new Resolver.Resolver(ethrDid)
+let resolver = new Resolver({...getResolver({infuraProjectId: '<get a free ID from infura.io>'})});
 
-// pass the JWT from step 1
+// use the JWT from step 1
 let verificationResponse = await didJWT.verifyJWT(jwt, {
-  resolver: resolver,
+  resolver,
   audience: 'did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74'
 })
 console.log(verificationResponse)
@@ -104,31 +103,45 @@ console.log(verificationResponse)
 A verification response is an object resembling:
 
 ```typescript
-{
+expect(verificationResponse).toEqual({
   payload: {
-    iat: 1571692448,
-    exp: 1957463421,
     aud: 'did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74',
     name: 'uPort Developer',
     iss: 'did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74'
   },
   didResolutionResult: {
     didDocumentMetadata: {},
-    didResolutionMetadata: {},
+    didResolutionMetadata: { contentType: 'application/did+ld+json' },
     didDocument: {
-      '@context': 'https://w3id.org/did/v1',
+      '@context': [
+        'https://www.w3.org/ns/did/v1',
+        'https://w3id.org/security/suites/secp256k1recovery-2020/v2'
+      ],
       id: 'did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74',
-      publicKey: [ [Object] ],
-      authentication: [ [Object] ]
+      verificationMethod: [
+        {
+          id: 'did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#controller',
+          type: 'EcdsaSecp256k1RecoveryMethod2020',
+          controller: 'did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74',
+          blockchainAccountId: 'eip155:1:0xF3beAC30C498D9E26865F34fCAa57dBB935b0D74'
+        }
+      ],
+      authentication: [
+        'did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#controller'
+      ],
+      assertionMethod: [
+        'did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#controller'
+      ]
     }
   },
   issuer: 'did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74',
   signer: {
-    id: 'did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner',
-    type: 'Secp256k1VerificationKey2018',
-    owner: 'did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74',
-    ethereumAddress: '0xf3beac30c498d9e26865f34fcaa57dbb935b0d74'
+    id: 'did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#controller',
+    type: 'EcdsaSecp256k1RecoveryMethod2020',
+    controller: 'did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74',
+    blockchainAccountId: 'eip155:1:0xF3beAC30C498D9E26865F34fCAa57dBB935b0D74'
   },
-  jwt: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzE2OTI0NDgsImV4cCI6MTk1NzQ2MzQyMSwiYXVkIjoiZGlkOmV0aHI6MHhmM2JlYWMzMGM0OThkOWUyNjg2NWYzNGZjYWE1N2RiYjkzNWIwZDc0IiwibmFtZSI6InVQb3J0IERldmVsb3BlciIsImlzcyI6ImRpZDpldGhyOjB4ZjNiZWFjMzBjNDk4ZDllMjY4NjVmMzRmY2FhNTdkYmI5MzViMGQ3NCJ9.xd_CSWukS6rK8y7GVvyH_c5yRsDXojM6BuKaf1ZMg0fsgpSBioS7jBfyk4ZZvS0iuFu4u4_771_PNWvmsvaZQQE'
-}
+  jwt: 'eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQiLCJuYW1lIjoidVBvcnQgRGV2ZWxvcGVyIiwiaXNzIjoiZGlkOmV0aHI6MHhmM2JlYWMzMGM0OThkOWUyNjg2NWYzNGZjYWE1N2RiYjkzNWIwZDc0In0.mAhpAnw-9u57hyAaDufj2GPMbmuZyPDlU7aYSUMKk7P_9_cF3iLk-hFjFhb5xaUQB5nXYrciw6ZJ2RSAZI-IDQ',
+  policies: {}
+})
 ```

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -1,0 +1,39 @@
+/**
+ * Error prefixes used for known verification failure cases.
+ *
+ * For compatibility, these error prefixes match the existing error messages, but will be adjusted in a future major
+ * version update to match the scenarios better.
+ *
+ * @beta
+ */
+export const enum JWT_ERROR {
+  /**
+   * Thrown when a JWT payload schema is unexpected or when validity period does not match
+   */
+  INVALID_JWT = 'invalid_jwt',
+  /**
+   * Thrown when the verifier audience does not match the one set in the JWT payload
+   */
+  INVALID_AUDIENCE = 'invalid_config',
+  /**
+   * Thrown when none of the public keys of the issuer match the signature of the JWT.
+   *
+   * This is equivalent to `NO_SUITABLE_KEYS` when the `proofPurpose` is NOT specified.
+   */
+  INVALID_SIGNATURE = 'invalid_signature',
+  /**
+   * Thrown when the DID document of the issuer does not have any keys that match the signature for the given
+   * `proofPurpose`.
+   *
+   * This is equivalent to `invalid_signature`, when a `proofPurpose` is specified.
+   */
+  NO_SUITABLE_KEYS = 'no_suitable_keys',
+  /**
+   * Thrown when the `alg` of the JWT or the encoding of the key is not supported
+   */
+  NOT_SUPPORTED = 'not_supported',
+  /**
+   * Thrown when the DID resolver is unable to resolve the issuer DID.
+   */
+  RESOLVER_ERROR = 'resolver_error',
+}

--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -42,6 +42,7 @@ export interface JWTVerifyPolicies {
   nbf?: boolean
   iat?: boolean
   exp?: boolean
+  aud?: boolean
 }
 
 export interface JWSCreationOptions {
@@ -149,9 +150,9 @@ export const SUPPORTED_PUBLIC_KEY_TYPES: PublicKeyTypes = {
 export const SELF_ISSUED_V2 = 'https://self-issued.me/v2'
 export const SELF_ISSUED_V0_1 = 'https://self-issued.me'
 
-// Exporting errorCodes in a machine readable format rather than human readable format to be used in higher level module
+// Exporting errorCodes in a machine-readable format rather than human-readable format to be used in higher level module
 export const INVALID_JWT = 'invalid_jwt'
-export const INAVLID_CONFIG = 'invalid_config'
+export const INVALID_CONFIG = 'invalid_config'
 export const INVALID_SIGNATURE = 'invalid_signature'
 export const NOT_SUPPORTED = 'not_supported'
 export const NO_SUITABLE_KEYS = 'no_suitable_keys'
@@ -400,7 +401,7 @@ export async function verifyJWT(
     if (options.policies?.exp !== false && payload.exp && payload.exp <= now - skewTime) {
       throw new Error(`invalid_jwt: JWT has expired: exp: ${payload.exp} < now: ${now}`)
     }
-    if (payload.aud) {
+    if (options.policies?.aud !== false && payload.aud) {
       if (!options.audience && !options.callbackUrl) {
         throw new Error('invalid_config: JWT audience is required but your app address has not been configured')
       }

--- a/src/__tests__/JWT.test.ts
+++ b/src/__tests__/JWT.test.ts
@@ -3,7 +3,7 @@ import { VerificationMethod } from 'did-resolver'
 import { TokenVerifier } from 'jsontokens'
 import MockDate from 'mockdate'
 import { fromString } from 'uint8arrays/from-string'
-import { getAddress } from "@ethersproject/address"
+import { getAddress } from '@ethersproject/address'
 import {
   createJWS,
   createJWT,
@@ -466,7 +466,13 @@ describe('verifyJWT()', () => {
       expect.assertions(2)
       // const jwt = await createJWT({nbf:FUTURE},{issuer:did,signer})
 
-      const jwt = await createJWT({ requested: ['name', 'phone'], nbf: new Date().getTime() + 1000000 }, { issuer: did, signer })
+      const jwt = await createJWT(
+        { requested: ['name', 'phone'], nbf: new Date().getTime() + 1000000 },
+        {
+          issuer: did,
+          signer,
+        }
+      )
       expect(verifier.verify(jwt)).toBe(true)
 
       const { payload } = await verifyJWT(jwt, { resolver, policies: { nbf: false } })
@@ -477,13 +483,18 @@ describe('verifyJWT()', () => {
       expect.assertions(2)
       // const jwt = await createJWT({nbf:FUTURE},{issuer:did,signer})
 
-      const jwt = await createJWT({ requested: ['name', 'phone'], nbf: new Date().getTime() + 10000 }, { issuer: did, signer })
+      const jwt = await createJWT(
+        { requested: ['name', 'phone'], nbf: new Date().getTime() + 10000 },
+        {
+          issuer: did,
+          signer,
+        }
+      )
       expect(verifier.verify(jwt)).toBe(true)
 
       const { payload } = await verifyJWT(jwt, { resolver, policies: { now: new Date().getTime() + 100000 } })
       return expect(payload).toBeDefined()
     })
-
 
     it('fails when nbf is in the future and iat is in the past', async () => {
       expect.assertions(1)
@@ -499,7 +510,7 @@ describe('verifyJWT()', () => {
       // const jwt = await createJWT({nbf:FUTURE,iat:PAST},{issuer:did,signer})
 
       const { payload } = await verifyJWT(jwt, { resolver, policies: { nbf: false } })
-      expect(payload).toBeDefined();
+      expect(payload).toBeDefined()
     })
     it('passes when nbf is missing and iat is in the past', async () => {
       expect.assertions(1)
@@ -520,7 +531,7 @@ describe('verifyJWT()', () => {
       const jwt =
         'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzODExMzMsImlzcyI6ImRpZDpldGhyOjB4ZjNiZWFjMzBjNDk4ZDllMjY4NjVmMzRmY2FhNTdkYmI5MzViMGQ3NCJ9.FJuHvf9Tby7b4I54Cm1nh8CvLg4QH2wt2K0WfyQaLqlr3NKKI5hAdLalgZksI25gLhNrZwQFnC-nzEOs9PI1SQ'
       // const jwt = await createJWT({iat:FUTURE},{issuer:did,signer})
-      const { payload } = await verifyJWT(jwt, { resolver, policies: { iat: false }})
+      const { payload } = await verifyJWT(jwt, { resolver, policies: { iat: false } })
       return expect(payload).toBeDefined()
     })
     it('passes when nbf and iat are both missing', async () => {
@@ -602,9 +613,7 @@ describe('verifyJWT()', () => {
       resolve: jest.fn().mockReturnValue({
         didDocument: {
           id: did,
-          verificationMethod: [
-            verificationMethod
-          ],
+          verificationMethod: [verificationMethod],
         },
       }),
     }
@@ -643,7 +652,7 @@ describe('verifyJWT()', () => {
     expect.assertions(1)
     const jwt = await createJWT({ exp: NOW - 1 }, { issuer: did, signer })
     const { payload } = await verifyJWT(jwt, { resolver, skewTime: 0, policies: { exp: false } })
-    return expect(payload).toBeDefined();
+    return expect(payload).toBeDefined()
   })
 
   it('accepts a valid audience', async () => {
@@ -684,6 +693,17 @@ describe('verifyJWT()', () => {
     await expect(verifyJWT(jwt, { resolver, audience: did })).rejects.toThrowError(
       /JWT audience does not match your DID or callback url/
     )
+  })
+
+  it('accepts invalid audience when override policy is used', async () => {
+    expect.assertions(2)
+    const jwt = await createJWT({ aud }, { issuer: did, signer })
+    const { payload, issuer } = await verifyJWT(jwt, {
+      resolver,
+      policies: { aud: false }
+    })
+    expect(payload).toBeDefined()
+    expect(issuer).toEqual(did)
   })
 
   it('rejects an invalid audience using callback_url where callback is wrong', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,17 +5,18 @@ import { ES256KSigner } from './signers/ES256KSigner'
 import { ES256Signer } from './signers/ES256Signer'
 import { EdDSASigner } from './signers/EdDSASigner'
 import {
-  verifyJWT,
+  createJWS,
   createJWT,
   decodeJWT,
-  verifyJWS,
-  createJWS,
-  Signer,
   JWTHeader,
   JWTPayload,
   JWTVerified,
+  Signer,
+  verifyJWS,
+  verifyJWT,
 } from './JWT'
 import { toEthereumAddress } from './Digest'
+
 export { JWE, createJWE, decryptJWE, Encrypter, Decrypter, ProtectedHeader, Recipient, RecipientHeader } from './JWE'
 export { ECDH, createX25519ECDH } from './ECDH'
 export {
@@ -54,3 +55,5 @@ export {
 export { JWTOptions, JWTVerifyOptions } from './JWT'
 
 export { base64ToBytes, base58ToBytes, hexToBytes } from './util'
+
+export * from './Errors'


### PR DESCRIPTION
fixes #239 
.. without the mentioned breaking change.
Errors are still thrown, but the prefixes for the known failure cases are also exported now as an enum.