### PR TITLE
fix: export error prefixes as object instead of enum

### DIFF
--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -6,34 +6,34 @@
  *
  * @beta
  */
-export const enum JWT_ERROR {
+export const JWT_ERROR = {
   /**
    * Thrown when a JWT payload schema is unexpected or when validity period does not match
    */
-  INVALID_JWT = 'invalid_jwt',
+  INVALID_JWT: 'invalid_jwt',
   /**
    * Thrown when the verifier audience does not match the one set in the JWT payload
    */
-  INVALID_AUDIENCE = 'invalid_config',
+  INVALID_AUDIENCE: 'invalid_config',
   /**
    * Thrown when none of the public keys of the issuer match the signature of the JWT.
    *
    * This is equivalent to `NO_SUITABLE_KEYS` when the `proofPurpose` is NOT specified.
    */
-  INVALID_SIGNATURE = 'invalid_signature',
+  INVALID_SIGNATURE: 'invalid_signature',
   /**
    * Thrown when the DID document of the issuer does not have any keys that match the signature for the given
    * `proofPurpose`.
    *
    * This is equivalent to `invalid_signature`, when a `proofPurpose` is specified.
    */
-  NO_SUITABLE_KEYS = 'no_suitable_keys',
+  NO_SUITABLE_KEYS: 'no_suitable_keys',
   /**
    * Thrown when the `alg` of the JWT or the encoding of the key is not supported
    */
-  NOT_SUPPORTED = 'not_supported',
+  NOT_SUPPORTED: 'not_supported',
   /**
    * Thrown when the DID resolver is unable to resolve the issuer DID.
    */
-  RESOLVER_ERROR = 'resolver_error',
+  RESOLVER_ERROR: 'resolver_error',
 }

--- a/src/__tests__/ES256Signer.test.ts
+++ b/src/__tests__/ES256Signer.test.ts
@@ -28,7 +28,7 @@ describe('Secp256r1 Signer', () => {
     const signer = ES256Signer(base58ToBytes(privateKey))
     const plaintext = 'thequickbrownfoxjumpedoverthelazyprogrammer'
     await expect(signer(plaintext)).resolves.toEqual(
-       'vOTe64WujVUjEiQrAlwaPJtNADx4usSlCfe8OXHS6Np1BqJdqdJX912pVwVlAjmbqR_TMVE5i5TWB_GJVgrHgg'
+      'vOTe64WujVUjEiQrAlwaPJtNADx4usSlCfe8OXHS6Np1BqJdqdJX912pVwVlAjmbqR_TMVE5i5TWB_GJVgrHgg'
     )
   })
 
@@ -51,7 +51,7 @@ describe('Secp256r1 Signer', () => {
       'vOTe64WujVUjEiQrAlwaPJtNADx4usSlCfe8OXHS6Np1BqJdqdJX912pVwVlAjmbqR_TMVE5i5TWB_GJVgrHgg'
     )
   })
-  
+
   it('refuses wrong key size (too short)', async () => {
     expect.assertions(1)
     const privateKey = '040f1dbf0a2ca86875447a7c010b0fc6d39d76859c458fbe8f2bf775a40ad7'

--- a/src/__tests__/JWT.test.ts
+++ b/src/__tests__/JWT.test.ts
@@ -700,7 +700,7 @@ describe('verifyJWT()', () => {
     const jwt = await createJWT({ aud }, { issuer: did, signer })
     const { payload, issuer } = await verifyJWT(jwt, {
       resolver,
-      policies: { aud: false }
+      policies: { aud: false },
     })
     expect(payload).toBeDefined()
     expect(issuer).toEqual(did)


### PR DESCRIPTION
This changes the `JWT_ERROR` collection from an enum to a plain object.

closes #243

Although this is technically a breaking change, not enough time has passed since the introduction of the original enum for it to gain any usage.