### PR TITLE
add support for SIOP request payloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint --ignore-pattern \"src/**/*.test.[jt]s\" \"src/**/*.[jt]s\"",
     "prepublishOnly": "yarn test:ci && yarn format && yarn lint",
-    "release": "semantic-release --debug"
+    "release": "semantic-release --debug",
+    "postinstall": "yarn build"
   },
   "author": "Pelle Braendgaard",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "jsontokens": "3.1.1",
     "jsonwebtoken": "^8.5.1",
     "jwk-to-pem": "^2.0.5",
-    "microbundle": "0.15.1",
     "mockdate": "3.0.5",
     "prettier": "2.7.1",
     "regenerator-runtime": "0.13.9",
@@ -103,6 +102,7 @@
     "elliptic": "^6.5.4",
     "js-sha3": "^0.8.0",
     "multiformats": "^9.6.5",
+    "microbundle": "0.15.1",
     "uint8arrays": "^3.0.0"
   },
   "eslintIgnore": [

--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -404,8 +404,8 @@ export async function verifyJWT(
 
   let did = ''
 
-  if (!payload.iss) {
-    throw new Error(`${JWT_ERROR.INVALID_JWT}: JWT iss is required`)
+  if (!payload.iss && !payload.client_id) {
+    throw new Error(`${JWT_ERROR.INVALID_JWT}: JWT iss or client_id are required`)
   }
 
   if (payload.iss === SELF_ISSUED_V2 || payload.iss === SELF_ISSUED_V2_VC_INTEROP) {
@@ -423,7 +423,7 @@ export async function verifyJWT(
     }
     did = payload.did
   } else {
-    did = payload.iss
+    did = payload.iss || payload.client_id
   }
 
   if (!did) {

--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -537,7 +537,7 @@ export async function resolveAuthenticator(
     // support legacy DID Documents that do not list assertionMethod
     if (
       proofPurpose.startsWith('assertion') &&
-      !Object.getOwnPropertyNames(didResult?.didDocument).includes('assertionMethod')
+      Object.getOwnPropertyNames(didResult?.didDocument).indexOf('assertionMethod') < 0
     ) {
       didResult.didDocument = { ...(<DIDDocument>didResult.didDocument) }
       didResult.didDocument.assertionMethod = [...publicKeysToCheck.map((pk) => pk.id)]


### PR DESCRIPTION
According to the JWT Presentation Profile, the Request's JWT does not contain an `iss` claim, it must have a `client_id` claim instead. See https://identity.foundation/jwt-vc-presentation-profile/#self-issued-op-request-object

<img width="406" alt="image" src="https://user-images.githubusercontent.com/178506/206527512-4f29b0f3-6493-4a18-ae60-5de2ec66d949.png">
