### PR TITLE
add support for SIOP request JWT

### DIFF
--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -402,7 +402,7 @@ export async function verifyJWT(
       : undefined
     : options.proofPurpose
 
-  let did = ''
+  let did
 
   if (!payload.iss && !payload.client_id) {
     throw new Error(`${JWT_ERROR.INVALID_JWT}: JWT iss or client_id are required`)

--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -422,8 +422,15 @@ export async function verifyJWT(
       throw new Error(`${JWT_ERROR.INVALID_JWT}: JWT did is required`)
     }
     did = payload.did
+  } else if (payload.scope === 'openid' && payload.redirect_uri) {
+    // SIOP Request payload
+    // https://identity.foundation/jwt-vc-presentation-profile/#self-issued-op-request-object
+    if (!payload.client_id) {
+      throw new Error(`${JWT_ERROR.INVALID_JWT}: JWT client_id is required`)
+    }
+    did = payload.client_id
   } else {
-    did = payload.iss || payload.client_id
+    did = payload.iss
   }
 
   if (!did) {

--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -404,8 +404,8 @@ export async function verifyJWT(
 
   let did = ''
 
-  if (!payload.iss) {
-    throw new Error(`${JWT_ERROR.INVALID_JWT}: JWT iss is required`)
+  if (!payload.iss && !payload.client_id) {
+    throw new Error(`${JWT_ERROR.INVALID_JWT}: JWT iss or client_id are required`)
   }
 
   if (payload.iss === SELF_ISSUED_V2 || payload.iss === SELF_ISSUED_V2_VC_INTEROP) {
@@ -423,7 +423,7 @@ export async function verifyJWT(
     }
     did = payload.did
   } else {
-    did = payload.iss
+    did = payload.iss || payload.client_id
   }
 
   if (!did) {

--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -422,7 +422,7 @@ export async function verifyJWT(
       throw new Error(`${JWT_ERROR.INVALID_JWT}: JWT did is required`)
     }
     did = payload.did
-  } else if (payload.scope === 'openid' && payload.redirect_uri) {
+  } else if (!payload.iss && payload.scope === 'openid' && payload.redirect_uri) {
     // SIOP Request payload
     // https://identity.foundation/jwt-vc-presentation-profile/#self-issued-op-request-object
     if (!payload.client_id) {

--- a/src/__tests__/JWT.test.ts
+++ b/src/__tests__/JWT.test.ts
@@ -1005,11 +1005,11 @@ describe('verifyJWT() for ES256K', () => {
     )
   })
 
-  it('rejects a pregenerated JWT without iss', async () => {
+  it('rejects a pregenerated JWT without iss or client_id', async () => {
     expect.assertions(1)
     const jwt =
       'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzMjExMzN9.aa3_8ZH99MjFoHTrNjOm7Pgq5VL5A13DHR5MTd_dBw2B_pWgNuz4N1tbrocTP0MgDlRbovKmTTDrGNjNMPqH3g'
-    await expect(verifyJWT(jwt, { resolver })).rejects.toThrowError(/JWT iss is required/)
+    await expect(verifyJWT(jwt, { resolver })).rejects.toThrowError(/JWT iss or client_id are required/)
   })
 
   it('rejects a self-issued v2 JWT without sub', async () => {


### PR DESCRIPTION
According to JWT Presentation Profile, the SIOP Request JWT does not contain an `iss` claim, it must have a `client_id` claim instead. See https://identity.foundation/jwt-vc-presentation-profile/#self-issued-op-request-object

<img width="373" alt="image" src="https://user-images.githubusercontent.com/178506/206537637-b68b5ae7-2eaf-4bc8-9ece-c3367e1f0b6b.png">
