### PR TITLE
feat: interpret publicKeyMultibase as multicodec

### DIFF
--- a/src/VerifierAlgorithm.ts
+++ b/src/VerifierAlgorithm.ts
@@ -1,15 +1,15 @@
 import { sha256, toEthereumAddress } from './Digest.js'
 import type { VerificationMethod } from 'did-resolver'
-import { bases } from 'multiformats/basics'
 import {
-  hexToBytes,
   base58ToBytes,
   base64ToBytes,
+  bytesToBigInt,
   bytesToHex,
   EcdsaSignature,
-  stringToBytes,
-  bytesToBigInt,
   ECDSASignature,
+  hexToBytes,
+  multibaseToBytes,
+  stringToBytes,
 } from './util.js'
 import { verifyBlockchainAccountId } from './blockchains/index.js'
 import { secp256k1 } from '@noble/curves/secp256k1'
@@ -67,9 +67,7 @@ export function extractPublicKeyBytes(pk: VerificationMethod): Uint8Array {
   ) {
     return base64ToBytes(pk.publicKeyJwk.x)
   } else if (pk.publicKeyMultibase) {
-    const { base16, base58btc, base64, base64url } = bases
-    const baseDecoder = base16.decoder.or(base58btc.decoder.or(base64.decoder.or(base64url.decoder)))
-    return baseDecoder.decode(pk.publicKeyMultibase)
+    return multibaseToBytes(pk.publicKeyMultibase)
   }
   return new Uint8Array()
 }
@@ -181,9 +179,11 @@ export function verifyEd25519(
 }
 
 type Verifier = (data: string, signature: string, authenticators: VerificationMethod[]) => VerificationMethod
+
 interface Algorithms {
   [name: string]: Verifier
 }
+
 const algorithms: Algorithms = {
   ES256: verifyES256,
   ES256K: verifyES256K,

--- a/src/__tests__/VerifierAlgorithm.test.ts
+++ b/src/__tests__/VerifierAlgorithm.test.ts
@@ -215,6 +215,7 @@ const publicKeyJwk = {
   y: bytesToBase64url(bigintToBytes(publicKeyPoint.y, 32)),
 }
 const publicKeyMultibase = bytesToMultibase(publicKeyBytes, 'base58btc')
+const publicKeyMultibaseMulticodec = bytesToMultibase(publicKeyBytes, 'base58btc', 'secp256k1-pub')
 const eip155 = toEthereumAddress(publicKeyHex)
 const bip122 = toBip122Address(publicKeyHex, 'undefined')
 const cosmosPrefix = 'example'
@@ -378,6 +379,17 @@ describe('ES256K', () => {
     const jwt = await createJWT({ bla: 'bla' }, { issuer: did, signer })
     const parts = jwt.match(/^([a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+)\.([a-zA-Z0-9_-]+)$/)
     const pubkey = Object.assign({ publicKeyMultibase }, ecKey2)
+    // @ts-ignore
+    delete pubkey.publicKeyHex
+    // @ts-ignore
+    return expect(verifier(parts[1], parts[2], [pubkey])).toEqual(pubkey)
+  })
+
+  it('validates with publicKeyMultibase multicodec', async () => {
+    expect.assertions(1)
+    const jwt = await createJWT({ bla: 'bla' }, { issuer: did, signer })
+    const parts = jwt.match(/^([a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+)\.([a-zA-Z0-9_-]+)$/)
+    const pubkey = Object.assign({ publicKeyMultibase: publicKeyMultibaseMulticodec }, ecKey2)
     // @ts-ignore
     delete pubkey.publicKeyHex
     // @ts-ignore

--- a/src/__tests__/didkey.test.ts
+++ b/src/__tests__/didkey.test.ts
@@ -63,4 +63,55 @@ describe('Ed25519', () => {
       },
     })
   })
+
+  it('handles EdDSA algorithm with did:peer', async () => {
+    expect.assertions(1)
+
+    const resolver = {
+      resolve: async () => ({
+        didDocumentMetadata: {},
+        didResolutionMetadata: {
+          contentType: 'application/did+ld+json',
+        },
+        didDocument: {
+          '@context': ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/suites/ed25519-2020/v1'],
+          id: 'did:peer:0z6MknNW5mvrUpssSJwZRQSinLWXzcECPtjzeKUsTR1Mvumfw',
+          verificationMethod: [
+            {
+              id: 'did:peer:0z6MknNW5mvrUpssSJwZRQSinLWXzcECPtjzeKUsTR1Mvumfw#6MknNW5mvrUpssSJwZRQSinLWXzcECPtjzeKUsTR1Mvumfw',
+              type: 'Ed25519VerificationKey2020',
+              controller: 'did:peer:0z6MknNW5mvrUpssSJwZRQSinLWXzcECPtjzeKUsTR1Mvumfw',
+              publicKeyMultibase: 'z6MknNW5mvrUpssSJwZRQSinLWXzcECPtjzeKUsTR1Mvumfw',
+            },
+          ],
+          authentication: [
+            'did:peer:0z6MknNW5mvrUpssSJwZRQSinLWXzcECPtjzeKUsTR1Mvumfw#6MknNW5mvrUpssSJwZRQSinLWXzcECPtjzeKUsTR1Mvumfw',
+          ],
+          assertionMethod: [
+            'did:peer:0z6MknNW5mvrUpssSJwZRQSinLWXzcECPtjzeKUsTR1Mvumfw#6MknNW5mvrUpssSJwZRQSinLWXzcECPtjzeKUsTR1Mvumfw',
+          ],
+          capabilityInvocation: [
+            'did:peer:0z6MknNW5mvrUpssSJwZRQSinLWXzcECPtjzeKUsTR1Mvumfw#6MknNW5mvrUpssSJwZRQSinLWXzcECPtjzeKUsTR1Mvumfw',
+          ],
+          capabilityDelegation: [
+            'did:peer:0z6MknNW5mvrUpssSJwZRQSinLWXzcECPtjzeKUsTR1Mvumfw#6MknNW5mvrUpssSJwZRQSinLWXzcECPtjzeKUsTR1Mvumfw',
+          ],
+        },
+      }),
+    }
+    const jwt =
+      'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5vdGhpbmciOiJlbHNlIG1hdHRlcnMifX0sIm5iZiI6MTY5NTA1MjE4MSwiaXNzIjoiZGlkOnBlZXI6MHo2TWtuTlc1bXZyVXBzc1NKd1pSUVNpbkxXWHpjRUNQdGp6ZUtVc1RSMU12dW1mdyJ9.mvgdqscXYjIXRuut83e8AfcBVdQJJOppQ9flohALoke_qRL9rR0FBOuBjWbf6uHftKv8lqUcqZuPnmsAJ0sbAA'
+    const { payload } = await verifyJWT(jwt, { resolver })
+    return expect(payload).toMatchObject({
+      iss: 'did:peer:0z6MknNW5mvrUpssSJwZRQSinLWXzcECPtjzeKUsTR1Mvumfw',
+      nbf: 1695052181,
+      vc: {
+        '@context': ['https://www.w3.org/2018/credentials/v1'],
+        credentialSubject: {
+          nothing: 'else matters',
+        },
+        type: ['VerifiableCredential'],
+      },
+    })
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,19 @@ export {
 
 export { type JWTOptions, type JWTVerifyOptions } from './JWT.js'
 
-export { base64ToBytes, base58ToBytes, hexToBytes, genX25519EphemeralKeyPair } from './util.js'
+export {
+  base64ToBytes,
+  bytesToBase64url,
+  base58ToBytes,
+  bytesToBase58,
+  hexToBytes,
+  bytesToHex,
+  genX25519EphemeralKeyPair,
+  multibaseToBytes,
+  bytesToMultibase,
+  supportedCodecs,
+} from './util.js'
+
+export { extractPublicKeyBytes } from './VerifierAlgorithm.js'
 
 export * from './Errors.js'


### PR DESCRIPTION
fixes #297

Some users of `publicKeyMultibase` actually encode a multicodec prefixed byte array.
This leads to keys that are not decoded properly and thus are not usable for verification.

This fix includes some heuristics to try to decode multibase directly if it fits known public key lengths and then attempt multicodec decoding.

This PR also exports the methods used for key conversions for use in other libraries.
