### PR TITLE
feat: add support for Multikey

### DIFF
--- a/src/ConditionalAlgorithm.ts
+++ b/src/ConditionalAlgorithm.ts
@@ -137,7 +137,7 @@ async function verifyConditionDelegated(
     }
   } else {
     try {
-      foundSigner = await verifyJWTDecoded({ header, payload, data, signature }, delegatedAuthenticator)
+      foundSigner = verifyJWTDecoded({ header, payload, data, signature }, delegatedAuthenticator)
     } catch (e) {
       if (!(e as Error).message.startsWith('invalid_signature:')) throw e
     }

--- a/src/__tests__/JWT.test.ts
+++ b/src/__tests__/JWT.test.ts
@@ -430,7 +430,7 @@ describe('verifyJWT() for ES256', () => {
       verificationMethod: [
         {
           id: `${did}#keys-1`,
-          type: 'JsonWebKey2020',
+          type: 'EcdsaSecp256r1VerificationKey2019',
           controller: did,
           publicKeyHex: publicKey,
         },

--- a/src/__tests__/xc20pEncryption.test.ts
+++ b/src/__tests__/xc20pEncryption.test.ts
@@ -199,10 +199,10 @@ describe('xc20pEncryption', () => {
         'resolver_error: Could not resolve did:test:3'
       )
       await expect(resolveX25519Encrypters([did4], resolver)).rejects.toThrowError(
-        'no_suitable_keys: Could not find x25519 key for did:test:4'
+        'no_suitable_keys: Could not find X25519 key for did:test:4'
       )
       await expect(resolveX25519Encrypters([did7], resolver)).rejects.toThrowError(
-        'no_suitable_keys: Could not find x25519 key for did:test:7'
+        'no_suitable_keys: Could not find X25519 key for did:test:7'
       )
     })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,8 +72,7 @@ export {
   multibaseToBytes,
   bytesToMultibase,
   supportedCodecs,
+  extractPublicKeyBytes,
 } from './util.js'
-
-export { extractPublicKeyBytes } from './VerifierAlgorithm.js'
 
 export * from './Errors.js'


### PR DESCRIPTION
fixes #304

This PR adds support for `Multikey` verification methods, both for signature verification and for key agreement.
I also added a few internal mappings for known key types, verification methods, algorithms and multiformat codecs.

BREAKING CHANGE: The return types have changed for  of `extractPublicKeyBytes()` and `multibaseToBytes()` from Uint8Arrays to Objects containing the `keyBytes: Uint8Array` and a decoded or inferred `keyType: string | undefined`

Merging this PR should trigger a major version bump