### PR TITLE
feat: Add support for custom signing algorithms

### DIFF
--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -581,7 +581,7 @@ export async function resolveAuthenticator(
   issuer: string,
   proofPurpose?: ProofPurposeTypes
 ): Promise<DIDAuthenticator> {
-  const types: string[] = SUPPORTED_PUBLIC_KEY_TYPES[alg as KNOWN_JWA]
+  const types: string[] = SUPPORTED_PUBLIC_KEY_TYPES[alg]
   if (!types || types.length === 0) {
     throw new Error(`${JWT_ERROR.NOT_SUPPORTED}: No supported signature types for algorithm ${alg}`)
   }

--- a/src/SignerAlgorithm.ts
+++ b/src/SignerAlgorithm.ts
@@ -57,11 +57,36 @@ const algorithms: SignerAlgorithms = {
   Ed25519: Ed25519SignerAlg(),
   EdDSA: Ed25519SignerAlg(),
 }
-
+/** */
 function SignerAlg(alg: string): SignerAlgorithm {
   const impl: SignerAlgorithm = algorithms[alg]
   if (!impl) throw new Error(`not_supported: Unsupported algorithm ${alg}`)
   return impl
+}
+
+/**
+ * Adds a new signing algorithm to the algorithm dictionary.
+ * @param alg - The name of the algorithm to add.
+ * @param impl - The implementation of the signing algorithm.
+ * @throws {Error} If the algorithm name is invalid (empty or not a string).
+ * @throws {Error} If the implementation is not a function.
+ * @throws {Error} If the algorithm already exists in the dictionary.
+ * @example
+ */
+export function AddSigningAlgorithm(alg: string, impl: SignerAlgorithm): void {
+  if (!alg || typeof alg !== 'string') {
+    throw new Error('Invalid algorithm name: must be a non-empty string')
+  }
+
+  if (!impl || typeof impl !== 'function') {
+    throw new Error('Invalid implementation: must be a function')
+  }
+
+  if (alg in algorithms) {
+    throw new Error(`Algorithm '${alg}' already exists`)
+  }
+
+  algorithms[alg] = impl
 }
 
 export default SignerAlg

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,11 +13,15 @@ import {
   type JWTPayload,
   type JWTVerified,
   type Signer,
+  type SignerAlgorithm,
   verifyJWS,
   verifyJWT,
 } from './JWT.js'
 
 export { toEthereumAddress, concatKDF } from './Digest.js'
+
+export { AddSigningAlgorithm } from './SignerAlgorithm.js'
+export { AddVerifierAlgorithm } from './VerifierAlgorithm.js'
 
 export { createJWE, decryptJWE } from './encryption/JWE.js'
 export { xc20pDirDecrypter, xc20pDirEncrypter } from './encryption/xc20pDir.js'
@@ -54,6 +58,7 @@ export {
   verifyJWS,
   createJWS,
   type Signer,
+  type SignerAlgorithm,
   type JWTHeader,
   type JWTPayload,
   type JWTVerified,

--- a/src/util.ts
+++ b/src/util.ts
@@ -76,7 +76,10 @@ export type KNOWN_VERIFICATION_METHOD =
 
 export type KNOWN_KEY_TYPE = 'Secp256k1' | 'Ed25519' | 'X25519' | 'Bls12381G1' | 'Bls12381G2' | 'P-256'
 
-export type PublicKeyTypes = Record<KNOWN_JWA, KNOWN_VERIFICATION_METHOD[]>
+export type PublicKeyTypes = Record<
+  KNOWN_JWA | (string & NonNullable<unknown>),
+  KNOWN_VERIFICATION_METHOD[] | (string[] & NonNullable<unknown>)
+>
 
 export const SUPPORTED_PUBLIC_KEY_TYPES: PublicKeyTypes = {
   ES256: ['JsonWebKey2020', 'Multikey', 'EcdsaSecp256r1VerificationKey2019'],
@@ -147,6 +150,29 @@ export const SUPPORTED_PUBLIC_KEY_TYPES: PublicKeyTypes = {
     'JsonWebKey2020',
     'Multikey',
   ],
+}
+
+/**
+ * Adds supported public key types for a specific algorithm to the global registry.
+ * @param alg - The name of the algorithm.
+ * @param keys - A record containing the supported key types for the algorithm.
+ * @throws {Error} If the algorithm name is invalid (empty or not a string).
+ * @throws {Error} If the keys object is invalid or doesn't contain the algorithm.
+ * @throws {Error} If the key types for the algorithm are not in an array format.
+ */
+export function AddVerifierSupportedKeys(alg: string, keys: Record<string, string[]>): void {
+  if (!alg || typeof alg !== 'string') {
+    throw new Error('Invalid algorithm name: must be a non-empty string')
+  }
+
+  if (!keys || typeof keys !== 'object' || !(alg in keys)) {
+    throw new Error(`Invalid keys object: must contain the '${alg}' algorithm`)
+  }
+
+  if (!Array.isArray(keys[alg])) {
+    throw new Error(`Invalid key types for '${alg}': must be an array of strings`)
+  }
+  SUPPORTED_PUBLIC_KEY_TYPES[alg] = keys[alg]
 }
 
 export const VM_TO_KEY_TYPE: Record<KNOWN_VERIFICATION_METHOD, KNOWN_KEY_TYPE | undefined> = {


### PR DESCRIPTION
Some use cases need signing algorithms that aren't available in the library. This change makes the library more flexible by letting users add their own algorithms for signing and verification.

This PR adds support for custom signing algorithms beyond the ones currently implemented in the library. The changes are split into three commits:
1. Library modifications to support custom algorithms.
2. New tests for coverage of new code.
3. Documentation updates for implementing custom algorithms.


The changes modify the existing algorithms Record to support customization, adding some functions to add the signing algorithm. No new dependencies are required

If needed, we have created a working example using EIP-712 (Typed structured data hashing and signing) here: 
https://github.com/AntonioAlarcon32/did-jwt-eth-typed-data-signature. Using EIP-712 allows signing of JWTs using wallets like Metamask without any DID document modification, which more coveniently couples DID management with Ethereum accounts.