### PR TITLE
chore(ci): bump GH action versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   build-test-publish:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@v4 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
@@ -19,7 +19,7 @@ jobs:
       - name: "Setup node with cache"
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,13 +4,13 @@ jobs:
   build-test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@v4 # v4
         with:
           fetch-depth: 0
       - name: "Setup node with cache"
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: yarn
 
       - run: yarn install --frozen-lockfile
@@ -19,6 +19,7 @@ jobs:
       - run: yarn run test:ci
 
       - name: "Upload coverage reports"
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
This should unblock most of the renovate bot automatic upgrades