### PR TITLE
Improve Invalid JWT Error Handling

### DIFF
--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -198,8 +198,8 @@ export function decodeJWT(jwt: string, recurse = true): JWTDecoded {
       return innerDecodedJwt
     }
     return decodedJwt
-  } catch (e) {
-    throw new Error('invalid_argument: Incorrect format JWT')
+  } catch (e: any) {
+    throw new Error(`invalid_argument: ${JWT_ERROR.INVALID_JWT}: ${e}`)
   }
 }
 

--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -198,7 +198,7 @@ export function decodeJWT(jwt: string, recurse = true): JWTDecoded {
       return innerDecodedJwt
     }
     return decodedJwt
-  } catch (e: any) {
+  } catch (e) {
     throw new Error(`invalid_argument: ${JWT_ERROR.INVALID_JWT}: ${e}`)
   }
 }


### PR DESCRIPTION
This PR adds the caught error to the error message.

Motivation: debugging interoperability issues between platforms.