### PR TITLE
[codex] Use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:decentralized-identity/did-jwt.git"
+    "url": "git+https://github.com/decentralized-identity/did-jwt.git"
   },
   "license": "Apache-2.0",
   "devDependencies": {


### PR DESCRIPTION
## What changed

Updated the package repository URL from the SSH-only form to the public git+https form.

## Why

The currently published npm metadata normalizes the source value to git+ssh, which can require GitHub SSH credentials in package tooling and automation. The HTTPS URL remains cloneable without SSH configuration.

This is metadata-only and does not change runtime code, dependencies, or the lockfile.

## Validation

- Direct Node assertion for repository.url
- yarn lint
- npm pack --dry-run --json
- 14 non-expired Jest suites passed: 319 tests, 20 snapshots
- git diff --check

The complete yarn test run has one existing failure in src/__tests__/didkey.test.ts because its fixed JWT expired in December 2025; the failure is unrelated to this package metadata change.