### PR TITLE
fix: reject non-NumericDate exp, nbf, and iat claims

### DIFF
--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -161,6 +161,14 @@ function encodeSection(data: any, shouldCanonicalize = false): string {
 
 export const NBF_SKEW = 300
 
+function isNumericDate(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+function hasTimeClaim(value: unknown): boolean {
+  return value !== undefined && value !== null
+}
+
 function decodeJWS(jws: string): JWSDecoded {
   const parts = jws.match(/^([a-zA-Z0-9_-]+)\.([a-zA-Z0-9_-]+)\.([a-zA-Z0-9_-]+)$/)
   if (parts) {
@@ -522,15 +530,28 @@ export async function verifyJWT(
     const skewTime = typeof options.skewTime !== 'undefined' && options.skewTime >= 0 ? options.skewTime : NBF_SKEW
 
     const nowSkewed = now + skewTime
-    if (options.policies?.nbf !== false && payload.nbf) {
+    if (options.policies?.nbf !== false && hasTimeClaim(payload.nbf)) {
+      if (!isNumericDate(payload.nbf)) {
+        throw new Error(`${JWT_ERROR.INVALID_JWT}: JWT nbf is not a NumericDate: ${payload.nbf}`)
+      }
       if (payload.nbf > nowSkewed) {
         throw new Error(`${JWT_ERROR.INVALID_JWT}: JWT not valid before nbf: ${payload.nbf}`)
       }
-    } else if (options.policies?.iat !== false && payload.iat && payload.iat > nowSkewed) {
-      throw new Error(`${JWT_ERROR.INVALID_JWT}: JWT not valid yet (issued in the future) iat: ${payload.iat}`)
+    } else if (options.policies?.iat !== false && hasTimeClaim(payload.iat)) {
+      if (!isNumericDate(payload.iat)) {
+        throw new Error(`${JWT_ERROR.INVALID_JWT}: JWT iat is not a NumericDate: ${payload.iat}`)
+      }
+      if (payload.iat > nowSkewed) {
+        throw new Error(`${JWT_ERROR.INVALID_JWT}: JWT not valid yet (issued in the future) iat: ${payload.iat}`)
+      }
     }
-    if (options.policies?.exp !== false && payload.exp && payload.exp <= now - skewTime) {
-      throw new Error(`${JWT_ERROR.INVALID_JWT}: JWT has expired: exp: ${payload.exp} < now: ${now}`)
+    if (options.policies?.exp !== false && hasTimeClaim(payload.exp)) {
+      if (!isNumericDate(payload.exp)) {
+        throw new Error(`${JWT_ERROR.INVALID_JWT}: JWT exp is not a NumericDate: ${payload.exp}`)
+      }
+      if (payload.exp <= now - skewTime) {
+        throw new Error(`${JWT_ERROR.INVALID_JWT}: JWT has expired: exp: ${payload.exp} < now: ${now}`)
+      }
     }
     if (options.policies?.aud !== false && payload.aud) {
       if (!options.audience && !options.callbackUrl) {

--- a/src/__tests__/JWT.test.ts
+++ b/src/__tests__/JWT.test.ts
@@ -907,6 +907,30 @@ describe('verifyJWT() for ES256K', () => {
     return expect(payload).toBeDefined()
   })
 
+  it('rejects exp 0 as expired', async () => {
+    expect.assertions(1)
+    const jwt = await createJWT({ exp: 0 }, { issuer: did, signer })
+    await expect(verifyJWT(jwt, { resolver })).rejects.toThrowError(/JWT has expired/)
+  })
+
+  it('rejects a non-numeric exp claim', async () => {
+    expect.assertions(1)
+    const jwt = await createJWT({ exp: 'never' as unknown as number }, { issuer: did, signer })
+    await expect(verifyJWT(jwt, { resolver })).rejects.toThrowError(/exp is not a NumericDate/)
+  })
+
+  it('rejects a non-numeric nbf claim', async () => {
+    expect.assertions(1)
+    const jwt = await createJWT({ nbf: 'soon' as unknown as number }, { issuer: did, signer })
+    await expect(verifyJWT(jwt, { resolver })).rejects.toThrowError(/nbf is not a NumericDate/)
+  })
+
+  it('rejects a non-numeric iat claim when nbf is absent', async () => {
+    expect.assertions(1)
+    const jwt = await createJWT({ iat: 'never' as unknown as number }, { issuer: did, signer })
+    await expect(verifyJWT(jwt, { resolver })).rejects.toThrowError(/iat is not a NumericDate/)
+  })
+
   it('accepts a valid audience', async () => {
     expect.assertions(1)
     const jwt = await createJWT({ aud }, { issuer: did, signer })

--- a/src/__tests__/didkey.test.ts
+++ b/src/__tests__/didkey.test.ts
@@ -41,7 +41,9 @@ describe('Ed25519', () => {
     }
     const jwt =
       'eyJhbGciOiJFZERTQSJ9.eyJleHAiOjE3NjQ4Nzg5MDgsImlzcyI6ImRpZDprZXk6ejZNa29USHNnTk5yYnk4SnpDTlExaVJMeVc1UVE2UjhYdXU2QUE4aWdHck1WUFVNIiwibmJmIjoxNjA3MTEyNTA4LCJzdWIiOiJkaWQ6a2V5Ono2TWtvVEhzZ05OcmJ5OEp6Q05RMWlSTHlXNVFRNlI4WHV1NkFBOGlnR3JNVlBVTSIsInZjIjp7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIiwiaHR0cHM6Ly9pZGVudGl0eS5mb3VuZGF0aW9uLy53ZWxsLWtub3duL2RpZC1jb25maWd1cmF0aW9uL3YxIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImlkIjoiZGlkOmtleTp6Nk1rb1RIc2dOTnJieThKekNOUTFpUkx5VzVRUTZSOFh1dTZBQThpZ0dyTVZQVU0iLCJvcmlnaW4iOiJpZGVudGl0eS5mb3VuZGF0aW9uIn0sImV4cGlyYXRpb25EYXRlIjoiMjAyNS0xMi0wNFQxNDowODoyOC0wNjowMCIsImlzc3VhbmNlRGF0ZSI6IjIwMjAtMTItMDRUMTQ6MDg6MjgtMDY6MDAiLCJpc3N1ZXIiOiJkaWQ6a2V5Ono2TWtvVEhzZ05OcmJ5OEp6Q05RMWlSTHlXNVFRNlI4WHV1NkFBOGlnR3JNVlBVTSIsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJEb21haW5MaW5rYWdlQ3JlZGVudGlhbCJdfX0.6ovgQ-T_rmYueviySqXhzMzgqJMAizOGUKAObQr2iikoRNsb8DHfna4rh1puwWqYwgT3QJVpzdO_xZARAYM9Dw'
-    const { payload } = await verifyJWT(jwt, { resolver })
+    // Hardcoded VC expired 2025-12-04. Pin verification time so the EdDSA
+    // path is still covered after that date (tip already rejected this JWT).
+    const { payload } = await verifyJWT(jwt, { resolver, policies: { now: 1764878908 } })
     return expect(payload).toMatchObject({
       exp: 1764878908,
       iss: 'did:key:z6MkoTHsgNNrby8JzCNQ1iRLyW5QQ6R8Xuu6AA8igGrMVPUM',


### PR DESCRIPTION
## Summary
- `verifyJWT` treated `exp`, `nbf`, and `iat` as present only when they were truthy. `exp: 0` and string values such as `"never"` skipped the RFC 7519 NumericDate window while the signature still verified.
- Fail closed when those claims are present but not a finite number. `exp: 0` is expired (1970-01-01). Missing claims stay optional, matching the existing policy flags.
- Pin `policies.now` on the hardcoded did:key VC. That fixture expired on 2025-12-04 and already failed on tip.

## Test plan
- [x] `yarn test` 326/326
- [x] Revert-test: the four new assertions fail when the guards are removed
- [x] `yarn lint`

Threat-model: the signer already controls the payload. The remaining verifier guard is the validity window. A present non-NumericDate claim turned that guard into a no-op.